### PR TITLE
feat: use distroless as resolver image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@
 ###    STAGE 1: Build cheqd did-resolver binary pre-requisites    ###
 #####################################################################
 
-FROM golang:1.17-alpine AS builder
+FROM golang:1.17 AS builder
 
 WORKDIR /resolver
 RUN apk add --no-cache git

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,23 +5,26 @@
 FROM golang:1.17-alpine AS builder
 
 WORKDIR /resolver
-COPY . ./
+RUN apk add --no-cache git
+COPY ./go.mod ./go.sum ./
+RUN go mod download
+COPY ./ ./
+
 
 # Build did-resolver binary
-RUN go mod download && go build -o cheqd-did-resolver main.go
+ENV CGO_ENABLED=0
+RUN go build -o cheqd-did-resolver main.go
 
 #####################################################################
 ###    STAGE 2: Build cheqd did-resolver container image          ###
 #####################################################################
 
-FROM alpine:3.16 AS resolver
-
-# Install pre-requisites
-RUN apk update && apk add --no-cache bash ca-certificates
+FROM gcr.io/distroless/static AS resolver
 
 # Set working directory & bash defaults
 WORKDIR /resolver
-SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
+USER nonroot:nonroot
 
 # Copy compiled cheqd-did-resolver binary from Stage 1
 COPY --from=builder /resolver/cheqd-did-resolver /bin/cheqd-did-resolver


### PR DESCRIPTION
In order to achieve more security and faster build times I updated the Dockerfile to fullfil the latest best practices.

* First Dependencies will be cached during a docker build so that the rebuilding goes faster
* Switched to distroless to reduce the attack vector inside the container and reduce image size by 8mb



[Distroless Static](https://github.com/GoogleContainerTools/distroless/blob/main/base/README.md#documentation-for-gcriodistrolessbase-and-gcriodistrolessstatic) contains the following things in the image: 

* ca-certificates
* A /etc/passwd entry for a root user
* A /tmp directory
* tzdata