### PR TITLE
fix: Add static checks to resolver before requests are sent to the ledger [DEV-2204]

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -96,6 +96,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/types.IdentityError"
                         }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/types.IdentityError"
+                        }
                     }
                 }
             }
@@ -168,6 +174,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/types.IdentityError"
                         }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/types.IdentityError"
+                        }
                     }
                 }
             }
@@ -231,6 +243,12 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/types.IdentityError"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
                         "schema": {
                             "$ref": "#/definitions/types.IdentityError"
                         }
@@ -301,6 +319,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/types.IdentityError"
                         }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/types.IdentityError"
+                        }
                     }
                 }
             }
@@ -368,6 +392,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/types.IdentityError"
                         }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/types.IdentityError"
+                        }
                     }
                 }
             }
@@ -432,6 +462,12 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/types.IdentityError"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
                         "schema": {
                             "$ref": "#/definitions/types.IdentityError"
                         }
@@ -504,6 +540,12 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/types.IdentityError"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
                         "schema": {
                             "$ref": "#/definitions/types.IdentityError"
                         }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -94,6 +94,12 @@
                         "schema": {
                             "$ref": "#/definitions/types.IdentityError"
                         }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/types.IdentityError"
+                        }
                     }
                 }
             }
@@ -166,6 +172,12 @@
                         "schema": {
                             "$ref": "#/definitions/types.IdentityError"
                         }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/types.IdentityError"
+                        }
                     }
                 }
             }
@@ -229,6 +241,12 @@
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/types.IdentityError"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
                         "schema": {
                             "$ref": "#/definitions/types.IdentityError"
                         }
@@ -299,6 +317,12 @@
                         "schema": {
                             "$ref": "#/definitions/types.IdentityError"
                         }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/types.IdentityError"
+                        }
                     }
                 }
             }
@@ -366,6 +390,12 @@
                         "schema": {
                             "$ref": "#/definitions/types.IdentityError"
                         }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/types.IdentityError"
+                        }
                     }
                 }
             }
@@ -430,6 +460,12 @@
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/types.IdentityError"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
                         "schema": {
                             "$ref": "#/definitions/types.IdentityError"
                         }
@@ -502,6 +538,12 @@
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/types.IdentityError"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
                         "schema": {
                             "$ref": "#/definitions/types.IdentityError"
                         }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -308,6 +308,10 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/types.IdentityError'
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/types.IdentityError'
       summary: Resolve DID Document on did:cheqd
       tags:
       - DID Resolution
@@ -354,6 +358,10 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/types.IdentityError'
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/types.IdentityError'
       summary: Fetch metadata for all Resources
       tags:
       - Resource Resolution
@@ -396,6 +404,10 @@ paths:
             $ref: '#/definitions/types.IdentityError'
         "500":
           description: Internal Server Error
+          schema:
+            $ref: '#/definitions/types.IdentityError'
+        "501":
+          description: Not Implemented
           schema:
             $ref: '#/definitions/types.IdentityError'
       summary: Fetch specific Resource
@@ -442,6 +454,10 @@ paths:
             $ref: '#/definitions/types.IdentityError'
         "500":
           description: Internal Server Error
+          schema:
+            $ref: '#/definitions/types.IdentityError'
+        "501":
+          description: Not Implemented
           schema:
             $ref: '#/definitions/types.IdentityError'
       summary: Fetch Resource-specific metadata
@@ -491,6 +507,10 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/types.IdentityError'
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/types.IdentityError'
       summary: Resolve DID Document Version on did:cheqd
       tags:
       - DID Resolution
@@ -538,6 +558,10 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/types.IdentityError'
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/types.IdentityError'
       summary: Resolve DID Document Version Metadata on did:cheqd
       tags:
       - DID Resolution
@@ -583,6 +607,10 @@ paths:
             $ref: '#/definitions/types.IdentityError'
         "500":
           description: Internal Server Error
+          schema:
+            $ref: '#/definitions/types.IdentityError'
+        "501":
+          description: Not Implemented
           schema:
             $ref: '#/definitions/types.IdentityError'
       summary: Resolve DID Document Versions on did:cheqd

--- a/services/ledger_service.go
+++ b/services/ledger_service.go
@@ -54,6 +54,7 @@ func NewLedgerService() LedgerService {
 //	@Failure		400			{object}	types.IdentityError
 //	@Failure		404			{object}	types.IdentityError
 //	@Failure		406			{object}	types.IdentityError
+//	@Failure		501			{object}	types.IdentityError
 //	@Failure		500			{object}	types.IdentityError
 //	@Router			/{did} [get]
 func (ls LedgerService) QueryDIDDoc(did string, version string) (*didTypes.DidDocWithMetadata, *types.IdentityError) {
@@ -103,6 +104,7 @@ func (ls LedgerService) QueryDIDDoc(did string, version string) (*didTypes.DidDo
 //	@Failure		400	{object}	types.IdentityError
 //	@Failure		404	{object}	types.IdentityError
 //	@Failure		406	{object}	types.IdentityError
+//	@Failure		501	{object}	types.IdentityError
 //	@Failure		500	{object}	types.IdentityError
 //	@Router			/{did}/versions [get]
 func (ls LedgerService) QueryAllDidDocVersionsMetadata(did string) ([]*didTypes.Metadata, *types.IdentityError) {
@@ -143,6 +145,7 @@ func (ls LedgerService) QueryAllDidDocVersionsMetadata(did string) ([]*didTypes.
 //	@Failure		400			{object}	types.IdentityError
 //	@Failure		404			{object}	types.IdentityError
 //	@Failure		406			{object}	types.IdentityError
+//	@Failure		501			{object}	types.IdentityError
 //	@Failure		500			{object}	types.IdentityError
 //	@Router			/{did}/resources/{resourceId} [get]
 func (ls LedgerService) QueryResource(did string, resourceId string) (*resourceTypes.ResourceWithMetadata, *types.IdentityError) {
@@ -184,6 +187,7 @@ func (ls LedgerService) QueryResource(did string, resourceId string) (*resourceT
 //	@Failure		400	{object}	types.IdentityError
 //	@Failure		404	{object}	types.IdentityError
 //	@Failure		406	{object}	types.IdentityError
+//	@Failure		501	{object}	types.IdentityError
 //	@Failure		500	{object}	types.IdentityError
 //	@Router			/{did}/metadata [get]
 func (ls LedgerService) QueryCollectionResources(did string) ([]*resourceTypes.Metadata, *types.IdentityError) {

--- a/services/request_service.go
+++ b/services/request_service.go
@@ -137,6 +137,7 @@ func (rs RequestService) ResolveDIDDocVersion(c echo.Context) error {
 //	@Failure		400			{object}	types.IdentityError
 //	@Failure		404			{object}	types.IdentityError
 //	@Failure		406			{object}	types.IdentityError
+//	@Failure		501			{object}	types.IdentityError
 //	@Failure		500			{object}	types.IdentityError
 //	@Router			/{did}/version/{versionId}/metadata [get]
 func (rs RequestService) ResolveDIDDocVersionMetadata(c echo.Context) error {
@@ -192,6 +193,7 @@ func (rs RequestService) ResolveDIDDocVersionMetadata(c echo.Context) error {
 //	@Failure		400			{object}	types.IdentityError
 //	@Failure		404			{object}	types.IdentityError
 //	@Failure		406			{object}	types.IdentityError
+//	@Failure		501			{object}	types.IdentityError
 //	@Failure		500			{object}	types.IdentityError
 //	@Router			/{did}/version/{versionId} [get]
 func (rs RequestService) ResolveAllDidDocVersionsMetadata(c echo.Context) error {
@@ -241,6 +243,7 @@ func (rs RequestService) ResolveAllDidDocVersionsMetadata(c echo.Context) error 
 //	@Failure		400			{object}	types.IdentityError
 //	@Failure		404			{object}	types.IdentityError
 //	@Failure		406			{object}	types.IdentityError
+//	@Failure		501			{object}	types.IdentityError
 //	@Failure		500			{object}	types.IdentityError
 //	@Router			/{did}/resources/{resourceId}/metadata [get]
 func (rs RequestService) DereferenceResourceMetadata(c echo.Context) error {

--- a/services/request_service.go
+++ b/services/request_service.go
@@ -93,6 +93,9 @@ func (rs RequestService) ResolveDIDDocVersion(c echo.Context) error {
 	}
 
 	version := c.Param("version")
+	if !utils.IsValidUUID(version) {
+		return types.NewInvalidDIDUrlError(c.Param("version"), requestedContentType, err, true)
+	}
 
 	didMethod, _, identifier, _ := types.TrySplitDID(did)
 	if didMethod != rs.didDocService.didMethod {
@@ -145,6 +148,9 @@ func (rs RequestService) ResolveDIDDocVersionMetadata(c echo.Context) error {
 	}
 
 	version := c.Param("version")
+	if !utils.IsValidUUID(version) {
+		return types.NewInvalidDIDUrlError(c.Param("version"), requestedContentType, err, true)
+	}
 
 	didMethod, _, identifier, _ := types.TrySplitDID(did)
 	if didMethod != rs.didDocService.didMethod {
@@ -243,7 +249,11 @@ func (rs RequestService) DereferenceResourceMetadata(c echo.Context) error {
 	if err != nil {
 		return types.NewInvalidDIDUrlError(c.Param("did"), requestedContentType, err, true)
 	}
+
 	resourceId := c.Param("resource")
+	if !utils.IsValidUUID(resourceId) {
+		return types.NewInvalidDIDUrlError(c.Param("resource"), requestedContentType, err, true)
+	}
 
 	didMethod, _, identifier, _ := types.TrySplitDID(did)
 	if didMethod != rs.didDocService.didMethod {
@@ -279,7 +289,11 @@ func (rs RequestService) DereferenceResourceData(c echo.Context) error {
 	if err != nil {
 		return types.NewInvalidDIDUrlError(c.Param("did"), requestedContentType, err, true)
 	}
+
 	resourceId := c.Param("resource")
+	if !utils.IsValidUUID(resourceId) {
+		return types.NewInvalidDIDUrlError(c.Param("resource"), requestedContentType, err, true)
+	}
 
 	didMethod, _, identifier, _ := types.TrySplitDID(did)
 	if didMethod != rs.didDocService.didMethod {

--- a/tests/pytest/test_resolution.py
+++ b/tests/pytest/test_resolution.py
@@ -207,7 +207,7 @@ def test_dereferencing_content_type_resource(accept, expected_header, expected_s
         (helpers.FAKE_TESTNET_FRAGMENT_1, 404),
         (helpers.FAKE_TESTNET_FRAGMENT_2, 404),
         (helpers.FAKE_TESTNET_RESOURCE, 404),
-        ("did:wrong_method:MTMxDQKMTMxDQKMT", 406),
+        ("did:wrong_method:MTMxDQKMTMxDQKMT", 501),
         (helpers.TESTNET_DID + "/", 400),
         (helpers.TESTNET_DID + "invalidDID", 400),
     ]

--- a/types/did_doc_metadata.go
+++ b/types/did_doc_metadata.go
@@ -5,6 +5,7 @@ import (
 
 	didTypes "github.com/cheqd/cheqd-node/api/v2/cheqd/did/v2"
 	resourceTypes "github.com/cheqd/cheqd-node/api/v2/cheqd/resource/v2"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type ResolutionDidDocMetadata struct {
@@ -16,11 +17,12 @@ type ResolutionDidDocMetadata struct {
 }
 
 func NewResolutionDidDocMetadata(did string, metadata *didTypes.Metadata, resources []*resourceTypes.Metadata) ResolutionDidDocMetadata {
-	created := metadata.Created.AsTime()
-	updated := metadata.Updated.AsTime()
+	created := toTime(metadata.Created)
+	updated := toTime(metadata.Updated)
+
 	newMetadata := ResolutionDidDocMetadata{
-		Created:     &created,
-		Updated:     &updated,
+		Created:     created,
+		Updated:     updated,
 		Deactivated: metadata.Deactivated,
 		VersionId:   metadata.VersionId,
 	}
@@ -41,3 +43,14 @@ func TransformToFragmentMetadata(metadata ResolutionDidDocMetadata) ResolutionDi
 func (e *ResolutionDidDocMetadata) AddContext(newProtocol string) {}
 func (e *ResolutionDidDocMetadata) RemoveContext()                {}
 func (e *ResolutionDidDocMetadata) GetBytes() []byte              { return []byte{} }
+
+func toTime(value *timestamppb.Timestamp) (result *time.Time) {
+	if value.AsTime().IsZero() {
+		result = nil
+	} else {
+		value := value.AsTime()
+		result = &value
+	}
+
+	return result
+}

--- a/types/errors.go
+++ b/types/errors.go
@@ -65,7 +65,7 @@ func NewRepresentationNotSupportedError(did string, contentType ContentType, err
 }
 
 func NewMethodNotSupportedError(did string, contentType ContentType, err error, isDereferencing bool) *IdentityError {
-	return NewIdentityError(406, "methodNotSupported", isDereferencing, did, contentType, err)
+	return NewIdentityError(501, "methodNotSupported", isDereferencing, did, contentType, err)
 }
 
 func NewInternalError(did string, contentType ContentType, err error, isDereferencing bool) *IdentityError {


### PR DESCRIPTION
- Added static validation for `versionId` and `resourceId`.
- Already added static validation for DID (length DID, namespace DID, etc.).
- Added correctly HTTP status code for `methodNotSupport` error.
- Fix problem with `updated` field in `DIDDocMetadata` type.
- Update swagger OpenAPI.