### PR TITLE
Allow integration tests to run against any accessible cheqd resolver

### DIFF
--- a/tests/constants/common.go
+++ b/tests/constants/common.go
@@ -3,6 +3,7 @@ package testconstants
 import (
 	"crypto/sha256"
 	"fmt"
+	"os"
 
 	didTypes "github.com/cheqd/cheqd-node/api/v2/cheqd/did/v2"
 	resourceTypes "github.com/cheqd/cheqd-node/api/v2/cheqd/resource/v2"
@@ -70,4 +71,13 @@ func generateChecksum(data []byte) string {
 	h.Write(data)
 
 	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+func getHostSUT() string {
+	host := os.Getenv("SUT_HOST_ADDRESS")
+	if host != "" {
+		return host
+	} else {
+		return "localhost:8080"
+	}
 }

--- a/tests/constants/constants.go
+++ b/tests/constants/constants.go
@@ -171,3 +171,5 @@ var (
 var DIDStructure = "did:%s:%s:%s"
 
 var HashTag = "\u0023"
+
+var SUTHost = getHostSUT()

--- a/tests/integration/rest/did_redirect_test.go
+++ b/tests/integration/rest/did_redirect_test.go
@@ -27,7 +27,8 @@ var _ = DescribeTable("Test HTTP status code of redirect DID URL", func(testCase
 		"can redirect when it try to get DIDDoc with an old 16 characters Indy style DID",
 		PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s",
+				"http://%s/1.0/identifiers/%s",
+				testconstants.SUTHost,
 				testconstants.OldIndy16CharStyleTestnetDid,
 			),
 			ResolutionType:     testconstants.DefaultResolutionType,
@@ -39,7 +40,8 @@ var _ = DescribeTable("Test HTTP status code of redirect DID URL", func(testCase
 		"can redirect when it try to get DIDDoc with an old 32 characters Indy style DID",
 		PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s",
+				"http://%s/1.0/identifiers/%s",
+				testconstants.SUTHost,
 				testconstants.OldIndy32CharStyleTestnetDid,
 			),
 			ResolutionType:     testconstants.DefaultResolutionType,
@@ -51,7 +53,8 @@ var _ = DescribeTable("Test HTTP status code of redirect DID URL", func(testCase
 		"can redirect when it try to get DIDDoc version with an old 16 characters Indy style DID",
 		PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s",
+				"http://%s/1.0/identifiers/%s/version/%s",
+				testconstants.SUTHost,
 				testconstants.OldIndy16CharStyleTestnetDid,
 				testconstants.ValidIdentifier,
 			),
@@ -64,7 +67,8 @@ var _ = DescribeTable("Test HTTP status code of redirect DID URL", func(testCase
 		"can redirect when it try to get DIDDoc version with an old 32 characters Indy style DID",
 		PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s",
+				"http://%s/1.0/identifiers/%s/version/%s",
+				testconstants.SUTHost,
 				testconstants.OldIndy32CharStyleTestnetDid,
 				testconstants.ValidIdentifier,
 			),
@@ -77,7 +81,8 @@ var _ = DescribeTable("Test HTTP status code of redirect DID URL", func(testCase
 		"can redirect when it try to get DIDDoc version metadata with an old 16 characters Indy style DID",
 		PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s/metadata",
+				"http://%s/1.0/identifiers/%s/version/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.OldIndy16CharStyleTestnetDid,
 				testconstants.ValidIdentifier,
 			),
@@ -90,7 +95,8 @@ var _ = DescribeTable("Test HTTP status code of redirect DID URL", func(testCase
 		"can redirect when it try to get DIDDoc version metadata with an old 32 characters Indy style DID",
 		PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s/metadata",
+				"http://%s/1.0/identifiers/%s/version/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.OldIndy32CharStyleTestnetDid,
 				testconstants.ValidIdentifier,
 			),
@@ -103,7 +109,8 @@ var _ = DescribeTable("Test HTTP status code of redirect DID URL", func(testCase
 		"can redirect when it try to get DIDDoc versions with an old 16 characters Indy style DID",
 		PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/versions",
+				"http://%s/1.0/identifiers/%s/versions",
+				testconstants.SUTHost,
 				testconstants.OldIndy16CharStyleTestnetDid,
 			),
 			ResolutionType:     testconstants.DefaultResolutionType,
@@ -115,7 +122,8 @@ var _ = DescribeTable("Test HTTP status code of redirect DID URL", func(testCase
 		"can redirect when it try to get DIDDoc versions with an old 32 characters Indy style DID",
 		PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/versions",
+				"http://%s/1.0/identifiers/%s/versions",
+				testconstants.SUTHost,
 				testconstants.OldIndy32CharStyleTestnetDid,
 			),
 			ResolutionType:     testconstants.DefaultResolutionType,
@@ -127,7 +135,8 @@ var _ = DescribeTable("Test HTTP status code of redirect DID URL", func(testCase
 		"can redirect when it try to get resource data with an old 16 characters Indy style DID",
 		PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/resources/%s",
+				"http://%s/1.0/identifiers/%s/resources/%s",
+				testconstants.SUTHost,
 				testconstants.OldIndy16CharStyleTestnetDid,
 				testconstants.ValidIdentifier,
 			),
@@ -140,7 +149,8 @@ var _ = DescribeTable("Test HTTP status code of redirect DID URL", func(testCase
 		"can redirect when it try to get resource data with an old 32 characters Indy style DID",
 		PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/resources/%s",
+				"http://%s/1.0/identifiers/%s/resources/%s",
+				testconstants.SUTHost,
 				testconstants.OldIndy32CharStyleTestnetDid,
 				testconstants.ValidIdentifier,
 			),
@@ -153,7 +163,8 @@ var _ = DescribeTable("Test HTTP status code of redirect DID URL", func(testCase
 		"can redirect when it try to get resource metadata with an old 16 characters Indy style DID",
 		PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/resources/%s/metadata",
+				"http://%s/1.0/identifiers/%s/resources/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.OldIndy16CharStyleTestnetDid,
 				testconstants.ValidIdentifier,
 			),
@@ -166,7 +177,8 @@ var _ = DescribeTable("Test HTTP status code of redirect DID URL", func(testCase
 		"can redirect when it try to get resource metadata with an old 32 characters Indy style DID",
 		PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/resources/%s/metadata",
+				"http://%s/1.0/identifiers/%s/resources/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.OldIndy32CharStyleTestnetDid,
 				testconstants.ValidIdentifier,
 			),
@@ -179,7 +191,8 @@ var _ = DescribeTable("Test HTTP status code of redirect DID URL", func(testCase
 		"can redirect when it try to get collection of resources with an old 16 characters Indy style DID",
 		PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/metadata",
+				"http://%s/1.0/identifiers/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.OldIndy16CharStyleTestnetDid,
 			),
 			ResolutionType:     testconstants.DefaultResolutionType,
@@ -191,7 +204,8 @@ var _ = DescribeTable("Test HTTP status code of redirect DID URL", func(testCase
 		"can redirect when it try to get collection of resources with an old 32 characters Indy style DID",
 		PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/metadata",
+				"http://%s/1.0/identifiers/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.OldIndy32CharStyleTestnetDid,
 			),
 			ResolutionType:     testconstants.DefaultResolutionType,
@@ -202,7 +216,8 @@ var _ = DescribeTable("Test HTTP status code of redirect DID URL", func(testCase
 		"can redirect when it try to get resource by query params. 16 symbols DID",
 		PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceId=%s",
+				"http://%s/1.0/identifiers/%s?resourceId=%s",
+				testconstants.SUTHost,
 				testconstants.OldIndy16CharStyleTestnetDid,
 				testconstants.ValidIdentifier,
 			),
@@ -214,7 +229,8 @@ var _ = DescribeTable("Test HTTP status code of redirect DID URL", func(testCase
 		"can redirect when it try to get resource by query params. 32 symbols DID",
 		PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceId=%s",
+				"http://%s/1.0/identifiers/%s?resourceId=%s",
+				testconstants.SUTHost,
 				testconstants.OldIndy32CharStyleTestnetDid,
 				testconstants.ValidIdentifier,
 			),

--- a/tests/integration/rest/diddoc/diddoc/negative_test.go
+++ b/tests/integration/rest/diddoc/diddoc/negative_test.go
@@ -37,7 +37,8 @@ var _ = DescribeTable("Negative: Get DIDDoc", func(testCase utils.NegativeTestCa
 		"cannot get DIDDoc with an existent DID, but not supported ResolutionType",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s",
+				"http://%s/1.0/identifiers/%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleMainnetDid,
 			),
 			ResolutionType: string(types.JSON),
@@ -59,7 +60,8 @@ var _ = DescribeTable("Negative: Get DIDDoc", func(testCase utils.NegativeTestCa
 		"cannot get DIDDoc with not existent DID and not supported ResolutionType",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s",
+				"http://%s/1.0/identifiers/%s",
+				testconstants.SUTHost,
 				testconstants.NotExistentMainnetDid,
 			),
 			ResolutionType: string(types.JSON),
@@ -81,7 +83,8 @@ var _ = DescribeTable("Negative: Get DIDDoc", func(testCase utils.NegativeTestCa
 		"cannot get DIDDoc with not existent mainnet DID",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s",
+				"http://%s/1.0/identifiers/%s",
+				testconstants.SUTHost,
 				testconstants.NotExistentMainnetDid,
 			),
 			ResolutionType: testconstants.DefaultResolutionType,
@@ -107,7 +110,8 @@ var _ = DescribeTable("Negative: Get DIDDoc", func(testCase utils.NegativeTestCa
 		"cannot get DIDDoc with not existent testnet DID",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s",
+				"http://%s/1.0/identifiers/%s",
+				testconstants.SUTHost,
 				testconstants.NotExistentTestnetDid,
 			),
 			ResolutionType: testconstants.DefaultResolutionType,
@@ -133,7 +137,8 @@ var _ = DescribeTable("Negative: Get DIDDoc", func(testCase utils.NegativeTestCa
 		"cannot get DIDDoc with mainnet DID that contains an invalid method",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s",
+				"http://%s/1.0/identifiers/%s",
+				testconstants.SUTHost,
 				testconstants.MainnetDidWithInvalidMethod,
 			),
 			ResolutionType: testconstants.DefaultResolutionType,
@@ -159,7 +164,8 @@ var _ = DescribeTable("Negative: Get DIDDoc", func(testCase utils.NegativeTestCa
 		"cannot get DIDDoc with testnet DID that contains an invalid method",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s",
+				"http://%s/1.0/identifiers/%s",
+				testconstants.SUTHost,
 				testconstants.TestnetDidWithInvalidMethod,
 			),
 			ResolutionType: testconstants.DefaultResolutionType,
@@ -185,7 +191,8 @@ var _ = DescribeTable("Negative: Get DIDDoc", func(testCase utils.NegativeTestCa
 		"cannot get DIDDoc with DID that contains an invalid namespace",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s",
+				"http://%s/1.0/identifiers/%s",
+				testconstants.SUTHost,
 				testconstants.DidWithInvalidNamespace,
 			),
 			ResolutionType: testconstants.DefaultResolutionType,
@@ -211,7 +218,8 @@ var _ = DescribeTable("Negative: Get DIDDoc", func(testCase utils.NegativeTestCa
 		"It cannot get DIDDoc with an invalid DID",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s",
+				"http://%s/1.0/identifiers/%s",
+				testconstants.SUTHost,
 				testconstants.InvalidDid,
 			),
 			ResolutionType: testconstants.DefaultResolutionType,

--- a/tests/integration/rest/diddoc/diddoc/positive_test.go
+++ b/tests/integration/rest/diddoc/diddoc/positive_test.go
@@ -40,7 +40,8 @@ var _ = DescribeTable("Positive: Get DIDDoc", func(testCase utils.PositiveTestCa
 		"can get DIDDoc with an existent 22 bytes INDY style mainnet DID",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s",
+				"http://%s/1.0/identifiers/%s",
+				testconstants.SUTHost,
 				testconstants.IndyStyleMainnetDid,
 			),
 			ResolutionType:       testconstants.DefaultResolutionType,
@@ -55,7 +56,8 @@ var _ = DescribeTable("Positive: Get DIDDoc", func(testCase utils.PositiveTestCa
 		"can get DIDDoc with an existent 22 bytes INDY style testnet DID",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s",
+				"http://%s/1.0/identifiers/%s",
+				testconstants.SUTHost,
 				testconstants.IndyStyleTestnetDid,
 			),
 			ResolutionType:       testconstants.DefaultResolutionType,
@@ -70,7 +72,8 @@ var _ = DescribeTable("Positive: Get DIDDoc", func(testCase utils.PositiveTestCa
 		"can get DIDDoc with an existent UUID style mainnet DID",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s",
+				"http://%s/1.0/identifiers/%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleMainnetDid,
 			),
 			ResolutionType:       testconstants.DefaultResolutionType,
@@ -85,7 +88,8 @@ var _ = DescribeTable("Positive: Get DIDDoc", func(testCase utils.PositiveTestCa
 		"can get DIDDoc with an existent UUID style testnet DID",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s",
+				"http://%s/1.0/identifiers/%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 			),
 			ResolutionType:       testconstants.DefaultResolutionType,
@@ -100,7 +104,8 @@ var _ = DescribeTable("Positive: Get DIDDoc", func(testCase utils.PositiveTestCa
 		"can get DIDDoc with an existent old 16 characters INDY style testnet DID",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s",
+				"http://%s/1.0/identifiers/%s",
+				testconstants.SUTHost,
 				testconstants.OldIndy16CharStyleTestnetDid,
 			),
 			ResolutionType:       testconstants.DefaultResolutionType,
@@ -115,7 +120,8 @@ var _ = DescribeTable("Positive: Get DIDDoc", func(testCase utils.PositiveTestCa
 		"can get DIDDoc with an existent old 32 characters INDY style testnet DID",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s",
+				"http://%s/1.0/identifiers/%s",
+				testconstants.SUTHost,
 				testconstants.OldIndy32CharStyleTestnetDid,
 			),
 			ResolutionType:       testconstants.DefaultResolutionType,
@@ -130,7 +136,8 @@ var _ = DescribeTable("Positive: Get DIDDoc", func(testCase utils.PositiveTestCa
 		"can get DIDDoc with an existent DID and supported DIDJSON resolution type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s",
+				"http://%s/1.0/identifiers/%s",
+				testconstants.SUTHost,
 				testconstants.IndyStyleMainnetDid,
 			),
 			ResolutionType:       string(types.DIDJSON),
@@ -145,7 +152,8 @@ var _ = DescribeTable("Positive: Get DIDDoc", func(testCase utils.PositiveTestCa
 		"can get DIDDoc with an existent DID and supported DIDJSONLD resolution type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s",
+				"http://%s/1.0/identifiers/%s",
+				testconstants.SUTHost,
 				testconstants.IndyStyleMainnetDid,
 			),
 			ResolutionType:       string(types.DIDJSONLD),
@@ -160,7 +168,8 @@ var _ = DescribeTable("Positive: Get DIDDoc", func(testCase utils.PositiveTestCa
 		"can get DIDDoc with an existent DID and supported JSONLD resolution type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s",
+				"http://%s/1.0/identifiers/%s",
+				testconstants.SUTHost,
 				testconstants.IndyStyleMainnetDid,
 			),
 			ResolutionType:       string(types.JSONLD),
@@ -175,7 +184,8 @@ var _ = DescribeTable("Positive: Get DIDDoc", func(testCase utils.PositiveTestCa
 		"can get DIDDoc with an existent DID and supported gzip encoding type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s",
+				"http://%s/1.0/identifiers/%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 			),
 			ResolutionType:       testconstants.DefaultResolutionType,
@@ -190,7 +200,8 @@ var _ = DescribeTable("Positive: Get DIDDoc", func(testCase utils.PositiveTestCa
 		"can get DIDDoc with an existent DID and not supported encoding type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s",
+				"http://%s/1.0/identifiers/%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 			),
 			ResolutionType:     testconstants.DefaultResolutionType,

--- a/tests/integration/rest/diddoc/fragment/negative_test.go
+++ b/tests/integration/rest/diddoc/fragment/negative_test.go
@@ -36,7 +36,8 @@ var _ = DescribeTable("Negative: Get DID#fragment", func(testCase utils.Negative
 		"cannot get DIDDoc fragment with an existent DID, but not supported ResolutionType",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%skey-1",
+				"http://%s/1.0/identifiers/%skey-1",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleMainnetDid+url.PathEscape(testconstants.HashTag),
 			),
 			ResolutionType: string(types.JSON),
@@ -58,7 +59,8 @@ var _ = DescribeTable("Negative: Get DID#fragment", func(testCase utils.Negative
 		"cannot get DIDDoc fragment with not existent DID and not supported ResolutionType",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%skey-1",
+				"http://%s/1.0/identifiers/%skey-1",
+				testconstants.SUTHost,
 				testconstants.NotExistentMainnetDid+url.PathEscape(testconstants.HashTag),
 			),
 			ResolutionType: string(types.JSON),
@@ -80,7 +82,8 @@ var _ = DescribeTable("Negative: Get DID#fragment", func(testCase utils.Negative
 		"cannot get DIDDoc fragment with not existent DID",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%skey1",
+				"http://%s/1.0/identifiers/%skey1",
+				testconstants.SUTHost,
 				testconstants.NotExistentTestnetDid+url.PathEscape(testconstants.HashTag),
 			),
 			ResolutionType: testconstants.DefaultResolutionType,
@@ -106,7 +109,8 @@ var _ = DescribeTable("Negative: Get DID#fragment", func(testCase utils.Negative
 		"cannot get DIDDoc fragment with an invalid DID",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%skey1",
+				"http://%s/1.0/identifiers/%skey1",
+				testconstants.SUTHost,
 				testconstants.InvalidDid+url.PathEscape(testconstants.HashTag),
 			),
 			ResolutionType: testconstants.DefaultResolutionType,
@@ -132,7 +136,8 @@ var _ = DescribeTable("Negative: Get DID#fragment", func(testCase utils.Negative
 		"cannot get DIDDoc fragment with existent DID, but not existent #fragment",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s%s",
+				"http://%s/1.0/identifiers/%s%s",
+				testconstants.SUTHost,
 				testconstants.IndyStyleTestnetDid+url.PathEscape(testconstants.HashTag),
 				testconstants.NotExistentFragment,
 			),
@@ -159,7 +164,8 @@ var _ = DescribeTable("Negative: Get DID#fragment", func(testCase utils.Negative
 		"cannot get DIDDoc fragment with existent old 16 characters Indy style DID, but not existent #fragment",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s%s",
+				"http://%s/1.0/identifiers/%s%s",
+				testconstants.SUTHost,
 				testconstants.OldIndy16CharStyleTestnetDid+url.PathEscape(testconstants.HashTag),
 				testconstants.NotExistentFragment,
 			),
@@ -186,7 +192,8 @@ var _ = DescribeTable("Negative: Get DID#fragment", func(testCase utils.Negative
 		"cannot get DIDDoc fragment with existent old 32 characters Indy style DID, but not existent #fragment",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s%s",
+				"http://%s/1.0/identifiers/%s%s",
+				testconstants.SUTHost,
 				testconstants.OldIndy32CharStyleTestnetDid+url.PathEscape(testconstants.HashTag),
 				testconstants.NotExistentFragment,
 			),

--- a/tests/integration/rest/diddoc/fragment/positive_test.go
+++ b/tests/integration/rest/diddoc/fragment/positive_test.go
@@ -41,7 +41,8 @@ var _ = DescribeTable("Positive: Get DID#fragment", func(testCase utils.Positive
 		"can get verificationMethod section with an existent DID#fragment",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%skey1",
+				"http://%s/1.0/identifiers/%skey1",
+				testconstants.SUTHost,
 				testconstants.IndyStyleMainnetDid+url.PathEscape(testconstants.HashTag),
 			),
 			ResolutionType:       testconstants.DefaultResolutionType,
@@ -56,7 +57,8 @@ var _ = DescribeTable("Positive: Get DID#fragment", func(testCase utils.Positive
 		"can get verificationMethod section with an existent old 16 characters Indy style DID#fragment",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%skey-1",
+				"http://%s/1.0/identifiers/%skey-1",
+				testconstants.SUTHost,
 				testconstants.OldIndy16CharStyleTestnetDid+url.PathEscape(testconstants.HashTag),
 			),
 			ResolutionType:       testconstants.DefaultResolutionType,
@@ -71,7 +73,8 @@ var _ = DescribeTable("Positive: Get DID#fragment", func(testCase utils.Positive
 		"can get verificationMethod section with an existent old 32 characters Indy style DID#fragment",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%skey-1",
+				"http://%s/1.0/identifiers/%skey-1",
+				testconstants.SUTHost,
 				testconstants.OldIndy32CharStyleTestnetDid+url.PathEscape(testconstants.HashTag),
 			),
 			ResolutionType:       testconstants.DefaultResolutionType,
@@ -86,7 +89,8 @@ var _ = DescribeTable("Positive: Get DID#fragment", func(testCase utils.Positive
 		"can get verificationMethod section with an existent DID#fragment and supported DIDJSON resolution type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%skey1",
+				"http://%s/1.0/identifiers/%skey1",
+				testconstants.SUTHost,
 				testconstants.IndyStyleMainnetDid+url.PathEscape(testconstants.HashTag),
 			),
 			ResolutionType:       string(types.DIDJSON),
@@ -101,7 +105,8 @@ var _ = DescribeTable("Positive: Get DID#fragment", func(testCase utils.Positive
 		"can get verificationMethod section with an existent DID#fragment and supported DIDJSONLD resolution type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%skey1",
+				"http://%s/1.0/identifiers/%skey1",
+				testconstants.SUTHost,
 				testconstants.IndyStyleMainnetDid+url.PathEscape(testconstants.HashTag),
 			),
 			ResolutionType:       string(types.DIDJSONLD),
@@ -116,7 +121,8 @@ var _ = DescribeTable("Positive: Get DID#fragment", func(testCase utils.Positive
 		"can get verificationMethod section with an existent DID#fragment and supported JSONLD resolution type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%skey1",
+				"http://%s/1.0/identifiers/%skey1",
+				testconstants.SUTHost,
 				testconstants.IndyStyleMainnetDid+url.PathEscape(testconstants.HashTag),
 			),
 			ResolutionType:       string(types.JSONLD),
@@ -131,7 +137,8 @@ var _ = DescribeTable("Positive: Get DID#fragment", func(testCase utils.Positive
 		"can get verificationMethod section with an existent DID#fragment and supported default encoding type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%skey1",
+				"http://%s/1.0/identifiers/%skey1",
+				testconstants.SUTHost,
 				testconstants.IndyStyleMainnetDid+url.PathEscape(testconstants.HashTag),
 			),
 			ResolutionType:       testconstants.DefaultResolutionType,
@@ -146,7 +153,8 @@ var _ = DescribeTable("Positive: Get DID#fragment", func(testCase utils.Positive
 		"can get verificationMethod section with an existent DID#fragment and supported gzip encoding type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%skey1",
+				"http://%s/1.0/identifiers/%skey1",
+				testconstants.SUTHost,
 				testconstants.IndyStyleMainnetDid+url.PathEscape(testconstants.HashTag),
 			),
 			ResolutionType:       testconstants.DefaultResolutionType,
@@ -161,7 +169,8 @@ var _ = DescribeTable("Positive: Get DID#fragment", func(testCase utils.Positive
 		"can get verificationMethod section with an existent DID#fragment and supported gzip encoding type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%skey1",
+				"http://%s/1.0/identifiers/%skey1",
+				testconstants.SUTHost,
 				testconstants.IndyStyleMainnetDid+url.PathEscape(testconstants.HashTag),
 			),
 			ResolutionType:       testconstants.DefaultResolutionType,
@@ -176,7 +185,8 @@ var _ = DescribeTable("Positive: Get DID#fragment", func(testCase utils.Positive
 		"can get serviceEndpoint section with an existent DID#fragment",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%swebsite",
+				"http://%s/1.0/identifiers/%swebsite",
+				testconstants.SUTHost,
 				testconstants.IndyStyleMainnetDid+url.PathEscape(testconstants.HashTag),
 			),
 			ResolutionType:       testconstants.DefaultResolutionType,
@@ -191,7 +201,8 @@ var _ = DescribeTable("Positive: Get DID#fragment", func(testCase utils.Positive
 		"can get serviceEndpoint section with an existent DID#fragment and supported DIDJSON resolution type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%swebsite",
+				"http://%s/1.0/identifiers/%swebsite",
+				testconstants.SUTHost,
 				testconstants.IndyStyleMainnetDid+url.PathEscape(testconstants.HashTag),
 			),
 			ResolutionType:       string(types.DIDJSON),
@@ -206,7 +217,8 @@ var _ = DescribeTable("Positive: Get DID#fragment", func(testCase utils.Positive
 		"can get serviceEndpoint section with an existent DID#fragment and supported DIDJSONLD resolution type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%swebsite",
+				"http://%s/1.0/identifiers/%swebsite",
+				testconstants.SUTHost,
 				testconstants.IndyStyleMainnetDid+url.PathEscape(testconstants.HashTag),
 			),
 			ResolutionType:       string(types.DIDJSONLD),
@@ -221,7 +233,8 @@ var _ = DescribeTable("Positive: Get DID#fragment", func(testCase utils.Positive
 		"can get serviceEndpoint section with an existent DID#fragment and supported JSONLD resolution type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%swebsite",
+				"http://%s/1.0/identifiers/%swebsite",
+				testconstants.SUTHost,
 				testconstants.IndyStyleMainnetDid+url.PathEscape(testconstants.HashTag),
 			),
 			ResolutionType:       string(types.JSONLD),
@@ -236,7 +249,8 @@ var _ = DescribeTable("Positive: Get DID#fragment", func(testCase utils.Positive
 		"can get serviceEndpoint section with an existent DID#fragment and supported gzip encoding type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%swebsite",
+				"http://%s/1.0/identifiers/%swebsite",
+				testconstants.SUTHost,
 				testconstants.IndyStyleMainnetDid+url.PathEscape(testconstants.HashTag),
 			),
 			ResolutionType:       testconstants.DefaultResolutionType,
@@ -251,7 +265,8 @@ var _ = DescribeTable("Positive: Get DID#fragment", func(testCase utils.Positive
 		"can get serviceEndpoint section with an existent DID#fragment and supported gzip encoding type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%swebsite",
+				"http://%s/1.0/identifiers/%swebsite",
+				testconstants.SUTHost,
 				testconstants.IndyStyleMainnetDid+url.PathEscape(testconstants.HashTag),
 			),
 			ResolutionType:     testconstants.DefaultResolutionType,

--- a/tests/integration/rest/diddoc/metadata/negative_test.go
+++ b/tests/integration/rest/diddoc/metadata/negative_test.go
@@ -35,7 +35,8 @@ var _ = DescribeTable("Negative: Get DIDDoc version metadata", func(testCase uti
 		"cannot get DIDDoc version metadata with an existent DID and versionId, but not supported ResolutionType",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s/metadata",
+				"http://%s/1.0/identifiers/%s/version/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleMainnetDid,
 				testconstants.ValidIdentifier,
 			),
@@ -58,7 +59,8 @@ var _ = DescribeTable("Negative: Get DIDDoc version metadata", func(testCase uti
 		"cannot get DIDDoc version metadata with not existent DID and not supported ResolutionType",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s/metadata",
+				"http://%s/1.0/identifiers/%s/version/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.NotExistentMainnetDid,
 				testconstants.ValidIdentifier,
 			),
@@ -81,7 +83,8 @@ var _ = DescribeTable("Negative: Get DIDDoc version metadata", func(testCase uti
 		"cannot get DIDDoc version metadata with not existent DID",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s/metadata",
+				"http://%s/1.0/identifiers/%s/version/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.NotExistentMainnetDid,
 				testconstants.ValidIdentifier,
 			),
@@ -108,7 +111,8 @@ var _ = DescribeTable("Negative: Get DIDDoc version metadata", func(testCase uti
 		"cannot get DIDDoc version metadata with an invalid DID",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s/metadata",
+				"http://%s/1.0/identifiers/%s/version/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.InvalidDid,
 				testconstants.ValidIdentifier,
 			),
@@ -135,7 +139,8 @@ var _ = DescribeTable("Negative: Get DIDDoc version metadata", func(testCase uti
 		"cannot get DIDDoc version metadata with an existent DID, but not existent versionId",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s/metadata",
+				"http://%s/1.0/identifiers/%s/version/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.IndyStyleMainnetDid,
 				testconstants.NotExistentIdentifier,
 			),
@@ -162,7 +167,8 @@ var _ = DescribeTable("Negative: Get DIDDoc version metadata", func(testCase uti
 		"cannot get DIDDoc version metadata with an existent old 16 characters Indy style DID, but not existent versionId",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s/metadata",
+				"http://%s/1.0/identifiers/%s/version/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.OldIndy16CharStyleTestnetDid,
 				testconstants.NotExistentIdentifier,
 			),
@@ -189,7 +195,8 @@ var _ = DescribeTable("Negative: Get DIDDoc version metadata", func(testCase uti
 		"cannot get DIDDoc version metadata with an existent old 32 characters Indy style DID, but not existent versionId",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s/metadata",
+				"http://%s/1.0/identifiers/%s/version/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.OldIndy32CharStyleTestnetDid,
 				testconstants.NotExistentIdentifier,
 			),
@@ -216,7 +223,8 @@ var _ = DescribeTable("Negative: Get DIDDoc version metadata", func(testCase uti
 		"cannot get DIDDoc version metadata with an existent DID, but an invalid versionId",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s/metadata",
+				"http://%s/1.0/identifiers/%s/version/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleMainnetDid,
 				testconstants.InvalidIdentifier,
 			),

--- a/tests/integration/rest/diddoc/metadata/positive_test.go
+++ b/tests/integration/rest/diddoc/metadata/positive_test.go
@@ -39,7 +39,8 @@ var _ = DescribeTable("Positive: Get DIDDoc version metadata", func(testCase uti
 		"can get DIDDoc version metadata with an existent 22 bytes INDY style mainnet DID and versionId",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s/metadata",
+				"http://%s/1.0/identifiers/%s/version/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.IndyStyleMainnetDid,
 				testconstants.IndyStyleMainnetVersionId,
 			),
@@ -55,7 +56,8 @@ var _ = DescribeTable("Positive: Get DIDDoc version metadata", func(testCase uti
 		"can get DIDDoc version metadata with an existent 22 bytes INDY style testnet DID and versionId",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s/metadata",
+				"http://%s/1.0/identifiers/%s/version/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.IndyStyleTestnetDid,
 				testconstants.IndyStyleTestnetVersionId,
 			),
@@ -71,7 +73,8 @@ var _ = DescribeTable("Positive: Get DIDDoc version metadata", func(testCase uti
 		"can get DIDDoc version metadata with an existent UUID style mainnet DID and versionId",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s/metadata",
+				"http://%s/1.0/identifiers/%s/version/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleMainnetDid,
 				testconstants.UUIDStyleMainnetVersionId,
 			),
@@ -87,7 +90,8 @@ var _ = DescribeTable("Positive: Get DIDDoc version metadata", func(testCase uti
 		"can get DIDDoc version metadata with an existent UUID style testnet DID and versionId",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s/metadata",
+				"http://%s/1.0/identifiers/%s/version/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.UUIDStyleTestnetVersionId,
 			),
@@ -103,7 +107,8 @@ var _ = DescribeTable("Positive: Get DIDDoc version metadata", func(testCase uti
 		"can get DIDDoc version metadata with an existent old 16 characters Indy style testnet DID and versionId",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s/metadata",
+				"http://%s/1.0/identifiers/%s/version/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.OldIndy16CharStyleTestnetDid,
 				"674e6cb5-8d7c-5c50-b0ff-d91bcbcbd5d6",
 			),
@@ -119,7 +124,8 @@ var _ = DescribeTable("Positive: Get DIDDoc version metadata", func(testCase uti
 		"can get DIDDoc version metadata with an existent old 32 characters Indy style testnet DID and versionId",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s/metadata",
+				"http://%s/1.0/identifiers/%s/version/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.OldIndy32CharStyleTestnetDid,
 				"1dc202d4-26ee-54a9-b091-8d2e1f609722",
 			),
@@ -135,7 +141,8 @@ var _ = DescribeTable("Positive: Get DIDDoc version metadata", func(testCase uti
 		"can get DIDDoc version metadata with an existent DID and versionId, and supported DIDJSON resolution type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s/metadata",
+				"http://%s/1.0/identifiers/%s/version/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.UUIDStyleTestnetVersionId,
 			),
@@ -151,7 +158,8 @@ var _ = DescribeTable("Positive: Get DIDDoc version metadata", func(testCase uti
 		"can get DIDDoc version metadata with an existent DID and versionId, and supported DIDJSONLD resolution type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s/metadata",
+				"http://%s/1.0/identifiers/%s/version/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.UUIDStyleTestnetVersionId,
 			),
@@ -167,7 +175,8 @@ var _ = DescribeTable("Positive: Get DIDDoc version metadata", func(testCase uti
 		"can get DIDDoc version metadata with an existent DID and versionId, and supported JSONLD resolution type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s/metadata",
+				"http://%s/1.0/identifiers/%s/version/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.UUIDStyleTestnetVersionId,
 			),
@@ -183,7 +192,8 @@ var _ = DescribeTable("Positive: Get DIDDoc version metadata", func(testCase uti
 		"can get DIDDoc version metadata with an existent DID and versionId, and supported gzip encoding type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s/metadata",
+				"http://%s/1.0/identifiers/%s/version/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.UUIDStyleTestnetVersionId,
 			),
@@ -199,7 +209,8 @@ var _ = DescribeTable("Positive: Get DIDDoc version metadata", func(testCase uti
 		"can get DIDDoc version metadata with an existent DID and versionId, and not supported encoding type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s/metadata",
+				"http://%s/1.0/identifiers/%s/version/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.UUIDStyleTestnetVersionId,
 			),

--- a/tests/integration/rest/diddoc/query/common_negative_test.go
+++ b/tests/integration/rest/diddoc/query/common_negative_test.go
@@ -35,7 +35,8 @@ var _ = DescribeTable("Negative: request with common query parameters", func(tes
 		"cannot get DIDDoc with combination of metadata and relativeRef query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?metadata=true&relativeRef=\u002Fabout",
+				"http://%s/1.0/identifiers/%s?metadata=true&relativeRef=\u002Fabout",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 			),
 			ResolutionType: testconstants.DefaultResolutionType,
@@ -61,7 +62,8 @@ var _ = DescribeTable("Negative: request with common query parameters", func(tes
 		"cannot get DIDDoc with combination of metadata and resourceId query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?metadata=true&resourceId=%s",
+				"http://%s/1.0/identifiers/%s?metadata=true&resourceId=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				"5e16a3f9-7c6e-4b6b-8e28-20f56780ee25",
 			),
@@ -88,7 +90,8 @@ var _ = DescribeTable("Negative: request with common query parameters", func(tes
 		"cannot get DIDDoc with combination of metadata and resourceName query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?metadata=true&resourceName=%s",
+				"http://%s/1.0/identifiers/%s?metadata=true&resourceName=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				"TestResource",
 			),
@@ -115,7 +118,8 @@ var _ = DescribeTable("Negative: request with common query parameters", func(tes
 		"cannot get DIDDoc with combination of metadata and resourceType query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?metadata=true&resourceType=%s",
+				"http://%s/1.0/identifiers/%s?metadata=true&resourceType=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				"TestType",
 			),
@@ -142,7 +146,8 @@ var _ = DescribeTable("Negative: request with common query parameters", func(tes
 		"cannot get DIDDoc with combination of metadata and resourceVersionTime query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?metadata=true&resourceVersionTime=%s",
+				"http://%s/1.0/identifiers/%s?metadata=true&resourceVersionTime=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				"2023-03-06T09:53:44Z",
 			),
@@ -169,7 +174,8 @@ var _ = DescribeTable("Negative: request with common query parameters", func(tes
 		"cannot get DIDDoc with combination of metadata and resourceCollectionId query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?metadata=true&resourceCollectionId=%s",
+				"http://%s/1.0/identifiers/%s?metadata=true&resourceCollectionId=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				"b5d70adf-31ca-4662-aa10-d3a54cd8f06c",
 			),
@@ -196,7 +202,8 @@ var _ = DescribeTable("Negative: request with common query parameters", func(tes
 		"cannot get DIDDoc with combination of metadata and resourceVersion query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?metadata=true&resourceVersion=%s",
+				"http://%s/1.0/identifiers/%s?metadata=true&resourceVersion=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				"b5d70adf-31ca-4662-aa10-d3a54cd8f06c",
 			),
@@ -223,7 +230,8 @@ var _ = DescribeTable("Negative: request with common query parameters", func(tes
 		"cannot get DIDDoc with combination of metadata and checksum query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?metadata=true&checksum=%s",
+				"http://%s/1.0/identifiers/%s?metadata=true&checksum=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				"b5d70adf-31ca-4662-aa10-d3a54cd8f06c",
 			),
@@ -250,7 +258,8 @@ var _ = DescribeTable("Negative: request with common query parameters", func(tes
 		"cannot get DIDDoc with combination of service and resourceId query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?service=%s&resourceId=%s",
+				"http://%s/1.0/identifiers/%s?service=%s&resourceId=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				"bar",
 				"5e16a3f9-7c6e-4b6b-8e28-20f56780ee25",
@@ -278,7 +287,8 @@ var _ = DescribeTable("Negative: request with common query parameters", func(tes
 		"cannot get DIDDoc with combination of service and resourceName query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?service=%s&resourceName=%s",
+				"http://%s/1.0/identifiers/%s?service=%s&resourceName=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				"bar",
 				"TestResource",
@@ -306,7 +316,8 @@ var _ = DescribeTable("Negative: request with common query parameters", func(tes
 		"cannot get DIDDoc with combination of service and resourceType query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?service=%s&resourceType=%s",
+				"http://%s/1.0/identifiers/%s?service=%s&resourceType=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				"bar",
 				"TestType",
@@ -334,7 +345,8 @@ var _ = DescribeTable("Negative: request with common query parameters", func(tes
 		"cannot get DIDDoc with combination of service and resourceVersionTime query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?service=%s&resourceVersionTime=%s",
+				"http://%s/1.0/identifiers/%s?service=%s&resourceVersionTime=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				"bar",
 				"2023-03-06T09:53:44Z",
@@ -362,7 +374,8 @@ var _ = DescribeTable("Negative: request with common query parameters", func(tes
 		"cannot get DIDDoc with combination of service and resourceMetadata query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?service=%s&resourceMetadata=true",
+				"http://%s/1.0/identifiers/%s?service=%s&resourceMetadata=true",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				"bar",
 			),
@@ -389,7 +402,8 @@ var _ = DescribeTable("Negative: request with common query parameters", func(tes
 		"cannot get DIDDoc with combination of service and resourceCollectionId query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?service=%s&resourceCollectionId=%s",
+				"http://%s/1.0/identifiers/%s?service=%s&resourceCollectionId=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				"bar",
 				"2023-03-06T09:53:44Z",
@@ -417,7 +431,8 @@ var _ = DescribeTable("Negative: request with common query parameters", func(tes
 		"cannot get DIDDoc with combination of service and resourceVersion query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?service=%s&resourceVersion=%s",
+				"http://%s/1.0/identifiers/%s?service=%s&resourceVersion=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				"bar",
 				"1.0",
@@ -445,7 +460,8 @@ var _ = DescribeTable("Negative: request with common query parameters", func(tes
 		"cannot get DIDDoc with combination of service and checksum query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?service=%s&checksum=%s",
+				"http://%s/1.0/identifiers/%s?service=%s&checksum=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				"bar",
 				"64ec88ca00b268e5ba1a35678a1b5316d212f4f366b2477232534a8aeca37f3c",

--- a/tests/integration/rest/diddoc/query/common_positive_test.go
+++ b/tests/integration/rest/diddoc/query/common_positive_test.go
@@ -37,7 +37,8 @@ var _ = DescribeTable("Positive: request with common query parameters", func(tes
 		"can get DIDDoc with an existent versionId and versionTime query parameters",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionId=%s&versionTime=%s",
+				"http://%s/1.0/identifiers/%s?versionId=%s&versionTime=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				"ce298b6f-594b-426e-b431-370d6bc5d3ad",
 				"2023-03-06T09:39:49Z",
@@ -52,7 +53,8 @@ var _ = DescribeTable("Positive: request with common query parameters", func(tes
 		"can get DIDDoc with an existent versionId and transformKeys query parameters",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionId=%s&transformKeys=%s",
+				"http://%s/1.0/identifiers/%s?versionId=%s&transformKeys=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				"ce298b6f-594b-426e-b431-370d6bc5d3ad",
 				types.JsonWebKey2020,
@@ -67,7 +69,8 @@ var _ = DescribeTable("Positive: request with common query parameters", func(tes
 		"can get DIDDoc with an existent versionId, versionTime, transformKeys",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionId=%s&versionTime=%s&transformKeys=%s",
+				"http://%s/1.0/identifiers/%s?versionId=%s&versionTime=%s&transformKeys=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				"ce298b6f-594b-426e-b431-370d6bc5d3ad",
 				"2023-03-06T09:39:49Z",
@@ -102,7 +105,8 @@ var _ = DescribeTable("Positive: request with common query parameters (metadata)
 		"can get DIDDoc metadata with an existent versionId query parameters and supported value of metadata",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionId=%s&metadata=true",
+				"http://%s/1.0/identifiers/%s?versionId=%s&metadata=true",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				"0ce23d04-5b67-4ea6-a315-788588e53f4e",
 			),
@@ -116,7 +120,8 @@ var _ = DescribeTable("Positive: request with common query parameters (metadata)
 		"can get DIDDoc metadata with an existent metadata and versionTime query parameters",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionTime=%s&metadata=true",
+				"http://%s/1.0/identifiers/%s?versionTime=%s&metadata=true",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				"2023-03-06T09:39:49Z",
 			),
@@ -130,7 +135,8 @@ var _ = DescribeTable("Positive: request with common query parameters (metadata)
 		"can get DIDDoc metadata with an existent metadata, versionId, versionTime query parameters",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionId=%s&versionTime=%s&metadata=true",
+				"http://%s/1.0/identifiers/%s?versionId=%s&versionTime=%s&metadata=true",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				"0ce23d04-5b67-4ea6-a315-788588e53f4e",
 				"2023-03-06T09:36:56Z",
@@ -163,7 +169,8 @@ var _ = DescribeTable("Positive: request with common query parameters (service)"
 		"can redirect to serviceEndpoint with existent service and versionId query parameters",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?service=%s&versionId=%s",
+				"http://%s/1.0/identifiers/%s?service=%s&versionId=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				serviceId,
 				"ce298b6f-594b-426e-b431-370d6bc5d3ad",
@@ -178,7 +185,8 @@ var _ = DescribeTable("Positive: request with common query parameters (service)"
 		"can redirect to serviceEndpoint with existent service and versionTime query parameters",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?service=%s&versionTime=%s",
+				"http://%s/1.0/identifiers/%s?service=%s&versionTime=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				serviceId,
 				"2023-03-06T09:39:49Z",
@@ -193,7 +201,8 @@ var _ = DescribeTable("Positive: request with common query parameters (service)"
 		"can redirect to serviceEndpoint with existent service, relativeRef, versionId, versionTime query parameters",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?service=%s&relativeRef=%s&versionId=%s&versionTime=%s",
+				"http://%s/1.0/identifiers/%s?service=%s&relativeRef=%s&versionId=%s&versionTime=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				serviceId,
 				"\u002Fabout",

--- a/tests/integration/rest/diddoc/query/metadata/negative_test.go
+++ b/tests/integration/rest/diddoc/query/metadata/negative_test.go
@@ -35,7 +35,8 @@ var _ = DescribeTable("Negative: Get DIDDoc with metadata query", func(testCase 
 		"cannot get DIDDoc metadata with not supported metadata query parameter value",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?metadata=not_supported_value",
+				"http://%s/1.0/identifiers/%s?metadata=not_supported_value",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 			),
 			ResolutionType: testconstants.DefaultResolutionType,
@@ -61,7 +62,8 @@ var _ = DescribeTable("Negative: Get DIDDoc with metadata query", func(testCase 
 		"cannot get DIDDoc metadata with supported metadata value, but not existent versionId query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?metadata=true&versionId=%s",
+				"http://%s/1.0/identifiers/%s?metadata=true&versionId=%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.NotExistentIdentifier,
 			),
@@ -88,7 +90,8 @@ var _ = DescribeTable("Negative: Get DIDDoc with metadata query", func(testCase 
 		"cannot get DIDDoc metadata with supported metadata value, but not existent versionTime query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?metadata=true&versionTime=%s",
+				"http://%s/1.0/identifiers/%s?metadata=true&versionTime=%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				"2023-01-22T11:58:10.390039347Z",
 			),
@@ -115,7 +118,8 @@ var _ = DescribeTable("Negative: Get DIDDoc with metadata query", func(testCase 
 		"cannot get DIDDoc metadata with supported metadata value, but not existent service query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?metadata=true&service=%s",
+				"http://%s/1.0/identifiers/%s?metadata=true&service=%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.NotExistentService,
 			),
@@ -142,7 +146,8 @@ var _ = DescribeTable("Negative: Get DIDDoc with metadata query", func(testCase 
 		"cannot get DIDDoc metadata with supported metadata value, but not existent versionId, versionTime, service query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?metadata=true&versionId=%s&versionTime=%s&service=%s",
+				"http://%s/1.0/identifiers/%s?metadata=true&versionId=%s&versionTime=%s&service=%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.NotExistentIdentifier,
 				"2023-01-22T11:58:10.390039347Z",

--- a/tests/integration/rest/diddoc/query/metadata/positive_test.go
+++ b/tests/integration/rest/diddoc/query/metadata/positive_test.go
@@ -37,7 +37,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with metadata query", func(testCase 
 		"can get DIDDoc metadata with metadata=true query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?metadata=true",
+				"http://%s/1.0/identifiers/%s?metadata=true",
+				testconstants.SUTHost,
 				testconstants.IndyStyleMainnetDid,
 			),
 			ResolutionType:     testconstants.DefaultResolutionType,
@@ -50,7 +51,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with metadata query", func(testCase 
 		"can get DIDDoc metadata with metadata=false query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?metadata=false",
+				"http://%s/1.0/identifiers/%s?metadata=false",
+				testconstants.SUTHost,
 				testconstants.IndyStyleMainnetDid,
 			),
 			ResolutionType:     testconstants.DefaultResolutionType,
@@ -63,7 +65,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with metadata query", func(testCase 
 		"can get DIDDoc metadata with an old 16 characters INDY style DID and metadata query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?metadata=true",
+				"http://%s/1.0/identifiers/%s?metadata=true",
+				testconstants.SUTHost,
 				testconstants.OldIndy16CharStyleTestnetDid,
 			),
 			ResolutionType:     testconstants.DefaultResolutionType,
@@ -76,7 +79,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with metadata query", func(testCase 
 		"can get DIDDoc metadata with an old 32 characters INDY style DID and metadata query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?metadata=true",
+				"http://%s/1.0/identifiers/%s?metadata=true",
+				testconstants.SUTHost,
 				testconstants.OldIndy32CharStyleTestnetDid,
 			),
 			ResolutionType:     testconstants.DefaultResolutionType,

--- a/tests/integration/rest/diddoc/query/service/negative_test.go
+++ b/tests/integration/rest/diddoc/query/service/negative_test.go
@@ -34,7 +34,8 @@ var _ = DescribeTable("Negative: Get DIDDoc with service query", func(testCase u
 		"cannot redirect to serviceEndpoint with not existent service query parameter",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?service=%s",
+				"http://%s/1.0/identifiers/%s?service=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				testconstants.NotExistentService,
 			),
@@ -61,7 +62,8 @@ var _ = DescribeTable("Negative: Get DIDDoc with service query", func(testCase u
 		"cannot redirect to serviceEndpoint with relativeRef query parameter",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?relativeRef=\u002Finfo",
+				"http://%s/1.0/identifiers/%s?relativeRef=\u002Finfo",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 			),
 			ResolutionType: testconstants.DefaultResolutionType,
@@ -87,7 +89,8 @@ var _ = DescribeTable("Negative: Get DIDDoc with service query", func(testCase u
 		"cannot redirect to serviceEndpoint with an existent service, but an invalid relativeRef URI parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?relativeRef=\u002Finfo",
+				"http://%s/1.0/identifiers/%s?relativeRef=\u002Finfo",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 			),
 			ResolutionType: testconstants.DefaultResolutionType,
@@ -113,7 +116,8 @@ var _ = DescribeTable("Negative: Get DIDDoc with service query", func(testCase u
 		"cannot redirect to serviceEndpoint with an existent service, but not existent versionId query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?service=%s&versionId=%s",
+				"http://%s/1.0/identifiers/%s?service=%s&versionId=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				serviceId,
 				testconstants.NotExistentIdentifier,
@@ -141,7 +145,8 @@ var _ = DescribeTable("Negative: Get DIDDoc with service query", func(testCase u
 		"cannot redirect to serviceEndpoint with an existent service, but not existent versionTime query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?service=%s&versionTime=%s",
+				"http://%s/1.0/identifiers/%s?service=%s&versionTime=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				serviceId,
 				"2023-03-06T09:36:56.56204903Z",
@@ -170,7 +175,8 @@ var _ = DescribeTable("Negative: Get DIDDoc with service query", func(testCase u
 		"cannot redirect to serviceEndpoint with an existent service, but not existent versionId and versionTime query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?service=%s&versionId=%s&versionTime=%s",
+				"http://%s/1.0/identifiers/%s?service=%s&versionId=%s&versionTime=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				serviceId,
 				testconstants.NotExistentIdentifier,

--- a/tests/integration/rest/diddoc/query/service/positive_test.go
+++ b/tests/integration/rest/diddoc/query/service/positive_test.go
@@ -35,7 +35,8 @@ var _ = DescribeTable("Positive: Get Service param", func(testCase utils.Positiv
 		"can redirect to serviceEndpoint with an existent service query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?service=%s",
+				"http://%s/1.0/identifiers/%s?service=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				serviceId,
 			),
@@ -48,7 +49,8 @@ var _ = DescribeTable("Positive: Get Service param", func(testCase utils.Positiv
 		"can redirect to serviceEndpoint with an existent service and a valid relativeRef URI query parameters",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?service=%s&relativeRef=foo",
+				"http://%s/1.0/identifiers/%s?service=%s&relativeRef=foo",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				serviceId,
 			),

--- a/tests/integration/rest/diddoc/query/transform_key/negative_test.go
+++ b/tests/integration/rest/diddoc/query/transform_key/negative_test.go
@@ -43,7 +43,8 @@ var _ = DescribeTable("Negative: Get DIDDoc with transformKeys query parameter",
 		"cannot get DIDDoc with not existent DID and not supported transformKeys query parameter",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?transformKeys=EDDSA",
+				"http://%s/1.0/identifiers/%s?transformKeys=EDDSA",
+				testconstants.SUTHost,
 				testconstants.NotExistentTestnetDid,
 			),
 			ResolutionType: testconstants.DefaultResolutionType,
@@ -69,7 +70,8 @@ var _ = DescribeTable("Negative: Get DIDDoc with transformKeys query parameter",
 		"cannot get DIDDoc with not supported transformKeys query parameter",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?transformKeys=EDDSA",
+				"http://%s/1.0/identifiers/%s?transformKeys=EDDSA",
+				testconstants.SUTHost,
 				didWithEd25519VerificationKey2018Key,
 			),
 			ResolutionType: testconstants.DefaultResolutionType,
@@ -95,7 +97,8 @@ var _ = DescribeTable("Negative: Get DIDDoc with transformKeys query parameter",
 		"cannot get DIDDoc with combination of transformKeys and metadata query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?transformKeys=%s&metadata=true",
+				"http://%s/1.0/identifiers/%s?transformKeys=%s&metadata=true",
+				testconstants.SUTHost,
 				didWithEd25519VerificationKey2018Key,
 				types.Ed25519VerificationKey2020,
 			),
@@ -122,7 +125,8 @@ var _ = DescribeTable("Negative: Get DIDDoc with transformKeys query parameter",
 		"cannot get DIDDoc with combination of transformKeys and resourceId query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?transformKeys=%s&resourceId=%s",
+				"http://%s/1.0/identifiers/%s?transformKeys=%s&resourceId=%s",
+				testconstants.SUTHost,
 				didWithEd25519VerificationKey2018Key,
 				types.Ed25519VerificationKey2020,
 				testconstants.ValidIdentifier,
@@ -150,7 +154,8 @@ var _ = DescribeTable("Negative: Get DIDDoc with transformKeys query parameter",
 		"cannot get DIDDoc with combination of transformKeys and resourceName query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?transformKeys=%s&resourceName=someName",
+				"http://%s/1.0/identifiers/%s?transformKeys=%s&resourceName=someName",
+				testconstants.SUTHost,
 				didWithEd25519VerificationKey2018Key,
 				types.Ed25519VerificationKey2020,
 			),
@@ -177,7 +182,8 @@ var _ = DescribeTable("Negative: Get DIDDoc with transformKeys query parameter",
 		"cannot get DIDDoc with combination of transformKeys and resourceType query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?transformKeys=%s&resourceType=someType",
+				"http://%s/1.0/identifiers/%s?transformKeys=%s&resourceType=someType",
+				testconstants.SUTHost,
 				didWithEd25519VerificationKey2018Key,
 				types.Ed25519VerificationKey2020,
 			),
@@ -204,7 +210,8 @@ var _ = DescribeTable("Negative: Get DIDDoc with transformKeys query parameter",
 		"cannot get DIDDoc with combination of transformKeys and resourceVersionTime query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?transformKeys=%s&resourceVersionTime=2006-01-02",
+				"http://%s/1.0/identifiers/%s?transformKeys=%s&resourceVersionTime=2006-01-02",
+				testconstants.SUTHost,
 				didWithEd25519VerificationKey2018Key,
 				types.Ed25519VerificationKey2020,
 			),
@@ -231,7 +238,8 @@ var _ = DescribeTable("Negative: Get DIDDoc with transformKeys query parameter",
 		"cannot get DIDDoc with combination of transformKeys and resourceMetadata query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?transformKeys=%s&resourceMetadata=true",
+				"http://%s/1.0/identifiers/%s?transformKeys=%s&resourceMetadata=true",
+				testconstants.SUTHost,
 				didWithEd25519VerificationKey2018Key,
 				types.Ed25519VerificationKey2020,
 			),
@@ -258,7 +266,8 @@ var _ = DescribeTable("Negative: Get DIDDoc with transformKeys query parameter",
 		"cannot get DIDDoc with combination of transformKeys and resourceCollectionId query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?transformKeys=%s&resourceCollectionId=%s",
+				"http://%s/1.0/identifiers/%s?transformKeys=%s&resourceCollectionId=%s",
+				testconstants.SUTHost,
 				didWithEd25519VerificationKey2018Key,
 				types.Ed25519VerificationKey2020,
 				testconstants.ValidIdentifier,
@@ -286,7 +295,8 @@ var _ = DescribeTable("Negative: Get DIDDoc with transformKeys query parameter",
 		"cannot get DIDDoc with combination of transformKeys and resourceVersion query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?transformKeys=%s&resourceVersion=someVersion",
+				"http://%s/1.0/identifiers/%s?transformKeys=%s&resourceVersion=someVersion",
+				testconstants.SUTHost,
 				didWithEd25519VerificationKey2018Key,
 				types.Ed25519VerificationKey2020,
 			),

--- a/tests/integration/rest/diddoc/query/transform_key/positive_test.go
+++ b/tests/integration/rest/diddoc/query/transform_key/positive_test.go
@@ -41,7 +41,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with transformKeys query parameter",
 		"can get DIDDoc (Ed25519VerificationKey2018) with supported Ed25519VerificationKey2018 transformKeys query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?transformKeys=%s",
+				"http://%s/1.0/identifiers/%s?transformKeys=%s",
+				testconstants.SUTHost,
 				didWithEd25519VerificationKey2018Key,
 				string(types.Ed25519VerificationKey2018),
 			),
@@ -55,7 +56,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with transformKeys query parameter",
 		"can get DIDDoc (Ed25519VerificationKey2018) with supported Ed25519VerificationKey2020 transformKeys query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?transformKeys=%s",
+				"http://%s/1.0/identifiers/%s?transformKeys=%s",
+				testconstants.SUTHost,
 				didWithEd25519VerificationKey2018Key,
 				string(types.Ed25519VerificationKey2020),
 			),
@@ -69,7 +71,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with transformKeys query parameter",
 		"can get DIDDoc (Ed25519VerificationKey2018) with supported JSONWebKey2020 transformKeys query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?transformKeys=%s",
+				"http://%s/1.0/identifiers/%s?transformKeys=%s",
+				testconstants.SUTHost,
 				didWithEd25519VerificationKey2018Key,
 				string(types.JsonWebKey2020),
 			),
@@ -83,7 +86,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with transformKeys query parameter",
 		"can get DIDDoc (Ed25519VerificationKey2020) with supported Ed25519VerificationKey2018 transformKeys query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?transformKeys=%s",
+				"http://%s/1.0/identifiers/%s?transformKeys=%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				string(types.Ed25519VerificationKey2018),
 			),
@@ -97,7 +101,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with transformKeys query parameter",
 		"can get DIDDoc (Ed25519VerificationKey2020) with supported Ed25519VerificationKey2020 transformKeys query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?transformKeys=%s",
+				"http://%s/1.0/identifiers/%s?transformKeys=%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				string(types.Ed25519VerificationKey2020),
 			),
@@ -111,7 +116,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with transformKeys query parameter",
 		"can get DIDDoc (Ed25519VerificationKey2020) with supported JSONWebKey2020 transformKeys query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?transformKeys=%s",
+				"http://%s/1.0/identifiers/%s?transformKeys=%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				string(types.JsonWebKey2020),
 			),
@@ -125,7 +131,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with transformKeys query parameter",
 		"can get DIDDoc (JSONWebKey2020) with supported Ed25519VerificationKey2018 transformKeys query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?transformKeys=%s",
+				"http://%s/1.0/identifiers/%s?transformKeys=%s",
+				testconstants.SUTHost,
 				didWithJsonWebKey2020Key,
 				string(types.Ed25519VerificationKey2018),
 			),
@@ -139,7 +146,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with transformKeys query parameter",
 		"can get DIDDoc (JSONWebKey2020) with supported Ed25519VerificationKey2020 transformKeys query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?transformKeys=%s",
+				"http://%s/1.0/identifiers/%s?transformKeys=%s",
+				testconstants.SUTHost,
 				didWithJsonWebKey2020Key,
 				string(types.Ed25519VerificationKey2020),
 			),
@@ -153,7 +161,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with transformKeys query parameter",
 		"can get DIDDoc (JSONWebKey2020) with supported JSONWebKey2020 transformKeys query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?transformKeys=%s",
+				"http://%s/1.0/identifiers/%s?transformKeys=%s",
+				testconstants.SUTHost,
 				didWithJsonWebKey2020Key,
 				string(types.JsonWebKey2020),
 			),
@@ -167,7 +176,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with transformKeys query parameter",
 		"can get DIDDoc (JSONWebKey2020) with an existent old 16 characters INDY style DID and supported Ed25519VerificationKey2018 transformKeys query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?transformKeys=%s",
+				"http://%s/1.0/identifiers/%s?transformKeys=%s",
+				testconstants.SUTHost,
 				testconstants.OldIndy16CharStyleTestnetDid,
 				string(types.Ed25519VerificationKey2018),
 			),
@@ -181,7 +191,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with transformKeys query parameter",
 		"can get DIDDoc (JSONWebKey2020) with an existent old 16 characters INDY style DID and supported Ed25519VerificationKey2020 transformKeys query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?transformKeys=%s",
+				"http://%s/1.0/identifiers/%s?transformKeys=%s",
+				testconstants.SUTHost,
 				testconstants.OldIndy16CharStyleTestnetDid,
 				string(types.Ed25519VerificationKey2020),
 			),
@@ -195,7 +206,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with transformKeys query parameter",
 		"can get DIDDoc (JSONWebKey2020) with an existent old 16 characters INDY style DID and supported JSONWebKey2020 transformKeys query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?transformKeys=%s",
+				"http://%s/1.0/identifiers/%s?transformKeys=%s",
+				testconstants.SUTHost,
 				testconstants.OldIndy16CharStyleTestnetDid,
 				string(types.JsonWebKey2020),
 			),
@@ -209,7 +221,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with transformKeys query parameter",
 		"can get DIDDoc (Ed25519VerificationKey2020) with an existent old 32 characters INDY style DID and supported Ed25519VerificationKey2018 transformKeys query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?transformKeys=%s",
+				"http://%s/1.0/identifiers/%s?transformKeys=%s",
+				testconstants.SUTHost,
 				testconstants.OldIndy32CharStyleTestnetDid,
 				string(types.Ed25519VerificationKey2018),
 			),
@@ -223,7 +236,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with transformKeys query parameter",
 		"can get DIDDoc (Ed25519VerificationKey2020) with an existent old 32 characters INDY style DID and supported Ed25519VerificationKey2020 transformKeys query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?transformKeys=%s",
+				"http://%s/1.0/identifiers/%s?transformKeys=%s",
+				testconstants.SUTHost,
 				testconstants.OldIndy32CharStyleTestnetDid,
 				string(types.Ed25519VerificationKey2020),
 			),
@@ -237,7 +251,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with transformKeys query parameter",
 		"can get DIDDoc (Ed25519VerificationKey2020) with an existent old 32 characters INDY style DID and supported JSONWebKey2020 transformKeys query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?transformKeys=%s",
+				"http://%s/1.0/identifiers/%s?transformKeys=%s",
+				testconstants.SUTHost,
 				testconstants.OldIndy32CharStyleTestnetDid,
 				string(types.JsonWebKey2020),
 			),
@@ -251,7 +266,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with transformKeys query parameter",
 		"can get DIDDoc (Ed25519VerificationKey2018) with supported Ed25519VerificationKey2020 transformKeys and DIDDoc versionId queries",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?transformKeys=%s&versionId=%s",
+				"http://%s/1.0/identifiers/%s?transformKeys=%s&versionId=%s",
+				testconstants.SUTHost,
 				didWithEd25519VerificationKey2018Key,
 				string(types.Ed25519VerificationKey2020),
 				"44f49254-8106-40ee-99ad-e50ac9517346",
@@ -266,7 +282,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with transformKeys query parameter",
 		"can get DIDDoc (Ed25519VerificationKey2018) with supported Ed25519VerificationKey2020 transformKeys and DIDDoc versionTime queries",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?transformKeys=%s&versionTime=%s",
+				"http://%s/1.0/identifiers/%s?transformKeys=%s&versionTime=%s",
+				testconstants.SUTHost,
 				didWithEd25519VerificationKey2018Key,
 				string(types.Ed25519VerificationKey2020),
 				"2023-02-21T14:28:48.406713879Z",

--- a/tests/integration/rest/diddoc/query/version_id/negative_test.go
+++ b/tests/integration/rest/diddoc/query/version_id/negative_test.go
@@ -36,7 +36,8 @@ var _ = DescribeTable("Negative: Get DIDDoc with versionId query", func(testCase
 		"cannot get DIDDoc with not existent versionId query parameter",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionId=%s",
+				"http://%s/1.0/identifiers/%s?versionId=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				testconstants.NotExistentIdentifier,
 			),
@@ -63,7 +64,8 @@ var _ = DescribeTable("Negative: Get DIDDoc with versionId query", func(testCase
 		"cannot get DIDDoc with an invalid versionId query parameter",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionId=%s",
+				"http://%s/1.0/identifiers/%s?versionId=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				testconstants.InvalidIdentifier,
 			),
@@ -90,7 +92,8 @@ var _ = DescribeTable("Negative: Get DIDDoc with versionId query", func(testCase
 		"cannot get DIDDoc with an existent versionId, but not existent versionTime query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionId=%s&versionTime=2023-03-06T09:59:21Z",
+				"http://%s/1.0/identifiers/%s?versionId=%s&versionTime=2023-03-06T09:59:21Z",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				testconstants.SeveralVersionsDIDVersionId,
 			),
@@ -117,7 +120,8 @@ var _ = DescribeTable("Negative: Get DIDDoc with versionId query", func(testCase
 		"cannot get DIDDoc with an existent versionId, but not supported transformKeys value query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionId=%s&transformKeys=EDDSA",
+				"http://%s/1.0/identifiers/%s?versionId=%s&transformKeys=EDDSA",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				testconstants.SeveralVersionsDIDVersionId,
 			),
@@ -144,7 +148,8 @@ var _ = DescribeTable("Negative: Get DIDDoc with versionId query", func(testCase
 		"cannot get DIDDoc with an existent versionId, but not existent service query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionId=%s&service=%s",
+				"http://%s/1.0/identifiers/%s?versionId=%s&service=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				testconstants.SeveralVersionsDIDVersionId,
 				testconstants.NotExistentService,
@@ -172,7 +177,8 @@ var _ = DescribeTable("Negative: Get DIDDoc with versionId query", func(testCase
 		"cannot get DIDDoc with an existent versionId, but not existent versionTime and service query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionId=%s&versionTime=%s&service=%s",
+				"http://%s/1.0/identifiers/%s?versionId=%s&versionTime=%s&service=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				testconstants.SeveralVersionsDIDVersionId,
 				"2023-03-06T09:59:21Z",

--- a/tests/integration/rest/diddoc/query/version_id/positive_test.go
+++ b/tests/integration/rest/diddoc/query/version_id/positive_test.go
@@ -38,7 +38,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with versionId query", func(testCase
 		"can get DIDDoc with versionId query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionId=%s",
+				"http://%s/1.0/identifiers/%s?versionId=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				"0ce23d04-5b67-4ea6-a315-788588e53f4e",
 			),
@@ -52,7 +53,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with versionId query", func(testCase
 		"can get DIDDoc with an old 16 characters INDY style DID and versionId query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionId=%s",
+				"http://%s/1.0/identifiers/%s?versionId=%s",
+				testconstants.SUTHost,
 				testconstants.OldIndy16CharStyleTestnetDid,
 				"674e6cb5-8d7c-5c50-b0ff-d91bcbcbd5d6",
 			),
@@ -66,7 +68,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with versionId query", func(testCase
 		"can get DIDDoc with an old 32 characters INDY style DID and versionId query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionId=%s",
+				"http://%s/1.0/identifiers/%s?versionId=%s",
+				testconstants.SUTHost,
 				testconstants.OldIndy32CharStyleTestnetDid,
 				"1dc202d4-26ee-54a9-b091-8d2e1f609722",
 			),

--- a/tests/integration/rest/diddoc/query/version_time/negative_test.go
+++ b/tests/integration/rest/diddoc/query/version_time/negative_test.go
@@ -35,7 +35,8 @@ var _ = DescribeTable("Negative: Get DIDDoc with versionTime query", func(testCa
 		"cannot get DIDDoc with not existent versionTime query parameter",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionTime=%s",
+				"http://%s/1.0/identifiers/%s?versionTime=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				"2023-03-06T09:36:54.56204903Z",
 			),
@@ -62,7 +63,8 @@ var _ = DescribeTable("Negative: Get DIDDoc with versionTime query", func(testCa
 		"cannot get DIDDoc with not supported format of versionTime query parameter (not supported format)",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionTime=%s",
+				"http://%s/1.0/identifiers/%s?versionTime=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				url.QueryEscape("06/03/2023 09:36:54"),
 			),
@@ -89,7 +91,8 @@ var _ = DescribeTable("Negative: Get DIDDoc with versionTime query", func(testCa
 		"cannot get DIDDoc with an invalid versionTime query parameter",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionTime=2023-03-06Z",
+				"http://%s/1.0/identifiers/%s?versionTime=2023-03-06Z",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 			),
 			ResolutionType: testconstants.DefaultResolutionType,
@@ -115,7 +118,8 @@ var _ = DescribeTable("Negative: Get DIDDoc with versionTime query", func(testCa
 		"cannot get DIDDoc with an existent versionTime, but not existent versionId query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionTime=%s&versionId=%s",
+				"http://%s/1.0/identifiers/%s?versionTime=%s&versionId=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				"2023-03-06T09:39:49.496306968Z",
 				testconstants.NotExistentIdentifier,
@@ -143,7 +147,8 @@ var _ = DescribeTable("Negative: Get DIDDoc with versionTime query", func(testCa
 		"cannot get DIDDoc with an existent versionTime, but not existent service query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionTime=%s&service=notexistent",
+				"http://%s/1.0/identifiers/%s?versionTime=%s&service=notexistent",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				"2023-03-06T09:39:49.496306968Z",
 			),
@@ -171,7 +176,8 @@ var _ = DescribeTable("Negative: Get DIDDoc with versionTime query", func(testCa
 		"cannot get DIDDoc with an existent versionTime, but not existent versionId and service query parameters",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionTime=%s&versionId=%s&service=notexistent",
+				"http://%s/1.0/identifiers/%s?versionTime=%s&versionId=%s&service=notexistent",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				"2023-03-06T09:39:49.496306968Z",
 				testconstants.NotExistentIdentifier,

--- a/tests/integration/rest/diddoc/query/version_time/positive_test.go
+++ b/tests/integration/rest/diddoc/query/version_time/positive_test.go
@@ -38,7 +38,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with versionTime query", func(testCa
 		"can get DIDDoc with an old 16 characters INDY style DID and versionTime query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionTime=%s",
+				"http://%s/1.0/identifiers/%s?versionTime=%s",
+				testconstants.SUTHost,
 				testconstants.OldIndy16CharStyleTestnetDid,
 				"2022-10-13T06:09:04Z",
 			),
@@ -52,7 +53,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with versionTime query", func(testCa
 		"can get DIDDoc with an old 32 characters INDY style DID and versionTime query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionTime=%s",
+				"http://%s/1.0/identifiers/%s?versionTime=%s",
+				testconstants.SUTHost,
 				testconstants.OldIndy32CharStyleTestnetDid,
 				"2022-10-12T08:57:25Z",
 			),
@@ -66,7 +68,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with versionTime query", func(testCa
 		"can get DIDDoc with versionTime query parameter (Layout format)",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionTime=%s",
+				"http://%s/1.0/identifiers/%s?versionTime=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				url.QueryEscape("03/06 09:39:50AM '23 +0000"),
 			),
@@ -80,7 +83,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with versionTime query", func(testCa
 		"can get DIDDoc with versionTime query parameter (ANSIC format)",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionTime=%s",
+				"http://%s/1.0/identifiers/%s?versionTime=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				url.QueryEscape("Mon Mar 06 09:39:50 2023"),
 			),
@@ -94,7 +98,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with versionTime query", func(testCa
 		"can get DIDDoc with versionTime query parameter (UnixDate format)",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionTime=%s",
+				"http://%s/1.0/identifiers/%s?versionTime=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				url.QueryEscape("Mon Mar 06 09:39:50 UTC 2023"),
 			),
@@ -108,7 +113,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with versionTime query", func(testCa
 		"can get DIDDoc with versionTime query parameter (RubyDate format)",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionTime=%s",
+				"http://%s/1.0/identifiers/%s?versionTime=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				url.QueryEscape("Mon Mar 06 09:39:50 +0000 2023"),
 			),
@@ -122,7 +128,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with versionTime query", func(testCa
 		"can get DIDDoc with versionTime query parameter (RFC822 format)",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionTime=%s",
+				"http://%s/1.0/identifiers/%s?versionTime=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				url.QueryEscape("06 Mar 23 09:40 UTC"),
 			),
@@ -136,7 +143,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with versionTime query", func(testCa
 		"can get DIDDoc with versionTime query parameter (RFC822Z format)",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionTime=%s",
+				"http://%s/1.0/identifiers/%s?versionTime=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				url.QueryEscape("06 Mar 23 09:40 +0000"),
 			),
@@ -150,7 +158,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with versionTime query", func(testCa
 		"can get DIDDoc with versionTime query parameter (RFC850 format)",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionTime=%s",
+				"http://%s/1.0/identifiers/%s?versionTime=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				url.QueryEscape("Monday, 06-Mar-23 09:39:50 UTC"),
 			),
@@ -164,7 +173,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with versionTime query", func(testCa
 		"can get DIDDoc with versionTime query parameter (RFC1123 format)",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionTime=%s",
+				"http://%s/1.0/identifiers/%s?versionTime=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				url.QueryEscape("Mon, 06 Mar 2023 09:39:50 UTC"),
 			),
@@ -178,7 +188,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with versionTime query", func(testCa
 		"can get DIDDoc with versionTime query parameter (RFC1123Z format)",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionTime=%s",
+				"http://%s/1.0/identifiers/%s?versionTime=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				url.QueryEscape("Mon, 06 Mar 2023 09:39:50 +0000"),
 			),
@@ -192,7 +203,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with versionTime query", func(testCa
 		"can get DIDDoc with versionTime query parameter (RFC3339 format)",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionTime=%s",
+				"http://%s/1.0/identifiers/%s?versionTime=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				"2023-03-06T09:39:50Z",
 			),
@@ -206,7 +218,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with versionTime query", func(testCa
 		"can get DIDDoc with versionTime query parameter (RFC3339Nano format)",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionTime=%s",
+				"http://%s/1.0/identifiers/%s?versionTime=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				"2023-03-06T09:39:49.496306968Z",
 			),
@@ -220,7 +233,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with versionTime query", func(testCa
 		"can get DIDDoc with versionTime query parameter (DateTime format)",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionTime=%s",
+				"http://%s/1.0/identifiers/%s?versionTime=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				url.QueryEscape("2023-03-06 09:39:50"),
 			),
@@ -234,7 +248,8 @@ var _ = DescribeTable("Positive: Get DIDDoc with versionTime query", func(testCa
 		"can get DIDDoc with versionTime query parameter (DateOnly format)",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionTime=%s",
+				"http://%s/1.0/identifiers/%s?versionTime=%s",
+				testconstants.SUTHost,
 				testconstants.SeveralVersionsDID,
 				"2023-03-07",
 			),

--- a/tests/integration/rest/diddoc/version/negative_test.go
+++ b/tests/integration/rest/diddoc/version/negative_test.go
@@ -35,7 +35,8 @@ var _ = DescribeTable("Negative: Get DIDDoc version", func(testCase utils.Negati
 		"cannot get DIDDoc version with an existent DID and versionId, but not supported ResolutionType",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s",
+				"http://%s/1.0/identifiers/%s/version/%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleMainnetDid,
 				testconstants.ValidIdentifier,
 			),
@@ -58,7 +59,8 @@ var _ = DescribeTable("Negative: Get DIDDoc version", func(testCase utils.Negati
 		"cannot get DIDDoc version with not existent DID and not supported ResolutionType",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s",
+				"http://%s/1.0/identifiers/%s/version/%s",
+				testconstants.SUTHost,
 				testconstants.NotExistentMainnetDid,
 				testconstants.ValidIdentifier,
 			),
@@ -81,7 +83,8 @@ var _ = DescribeTable("Negative: Get DIDDoc version", func(testCase utils.Negati
 		"cannot get DIDDoc version with not existent DID",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s",
+				"http://%s/1.0/identifiers/%s/version/%s",
+				testconstants.SUTHost,
 				testconstants.NotExistentMainnetDid,
 				testconstants.ValidIdentifier,
 			),
@@ -108,7 +111,8 @@ var _ = DescribeTable("Negative: Get DIDDoc version", func(testCase utils.Negati
 		"cannot get DIDDoc version with invalid DID",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s",
+				"http://%s/1.0/identifiers/%s/version/%s",
+				testconstants.SUTHost,
 				testconstants.InvalidDid,
 				testconstants.ValidIdentifier,
 			),
@@ -135,7 +139,8 @@ var _ = DescribeTable("Negative: Get DIDDoc version", func(testCase utils.Negati
 		"cannot get DIDDoc with an existent DID, but not existent versionId",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s",
+				"http://%s/1.0/identifiers/%s/version/%s",
+				testconstants.SUTHost,
 				testconstants.IndyStyleMainnetDid,
 				testconstants.NotExistentIdentifier,
 			),
@@ -162,7 +167,8 @@ var _ = DescribeTable("Negative: Get DIDDoc version", func(testCase utils.Negati
 		"cannot get DIDDoc with an existent old 16 characters Indy style DID, but not existent versionId",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s",
+				"http://%s/1.0/identifiers/%s/version/%s",
+				testconstants.SUTHost,
 				testconstants.OldIndy16CharStyleTestnetDid,
 				testconstants.NotExistentIdentifier,
 			),
@@ -189,7 +195,8 @@ var _ = DescribeTable("Negative: Get DIDDoc version", func(testCase utils.Negati
 		"cannot get DIDDoc with an existent old 32 characters Indy style DID, but not existent versionId",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s",
+				"http://%s/1.0/identifiers/%s/version/%s",
+				testconstants.SUTHost,
 				testconstants.OldIndy32CharStyleTestnetDid,
 				testconstants.NotExistentIdentifier,
 			),
@@ -216,7 +223,8 @@ var _ = DescribeTable("Negative: Get DIDDoc version", func(testCase utils.Negati
 		"cannot get DIDDoc with an existent DID, but an invalid versionId",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s",
+				"http://%s/1.0/identifiers/%s/version/%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleMainnetDid,
 				testconstants.InvalidIdentifier,
 			),

--- a/tests/integration/rest/diddoc/version/positive_test.go
+++ b/tests/integration/rest/diddoc/version/positive_test.go
@@ -39,7 +39,8 @@ var _ = DescribeTable("Positive: Get DIDDoc version", func(testCase utils.Positi
 		"can get DIDDoc version with an existent 22 bytes INDY style mainnet DID and versionId",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s",
+				"http://%s/1.0/identifiers/%s/version/%s",
+				testconstants.SUTHost,
 				testconstants.IndyStyleMainnetDid,
 				testconstants.IndyStyleMainnetVersionId,
 			),
@@ -55,7 +56,8 @@ var _ = DescribeTable("Positive: Get DIDDoc version", func(testCase utils.Positi
 		"can get DIDDoc version with an existent 22 bytes INDY style testnet DID and versionId",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s",
+				"http://%s/1.0/identifiers/%s/version/%s",
+				testconstants.SUTHost,
 				testconstants.IndyStyleTestnetDid,
 				testconstants.IndyStyleTestnetVersionId,
 			),
@@ -71,7 +73,8 @@ var _ = DescribeTable("Positive: Get DIDDoc version", func(testCase utils.Positi
 		"can get DIDDoc version with an existent UUID style mainnet DID and versionId",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s",
+				"http://%s/1.0/identifiers/%s/version/%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleMainnetDid,
 				testconstants.UUIDStyleMainnetVersionId,
 			),
@@ -87,7 +90,8 @@ var _ = DescribeTable("Positive: Get DIDDoc version", func(testCase utils.Positi
 		"can get DIDDoc version with an existent UUID style testnet DID and versionId",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s",
+				"http://%s/1.0/identifiers/%s/version/%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.UUIDStyleTestnetVersionId,
 			),
@@ -103,7 +107,8 @@ var _ = DescribeTable("Positive: Get DIDDoc version", func(testCase utils.Positi
 		"can get DIDDoc version with an existent old 16 characters Indy style DID",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s",
+				"http://%s/1.0/identifiers/%s/version/%s",
+				testconstants.SUTHost,
 				testconstants.OldIndy16CharStyleTestnetDid,
 				"674e6cb5-8d7c-5c50-b0ff-d91bcbcbd5d6",
 			),
@@ -119,7 +124,8 @@ var _ = DescribeTable("Positive: Get DIDDoc version", func(testCase utils.Positi
 		"can get DIDDoc version with an existent old 32 characters Indy style DID",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s",
+				"http://%s/1.0/identifiers/%s/version/%s",
+				testconstants.SUTHost,
 				testconstants.OldIndy32CharStyleTestnetDid,
 				"1dc202d4-26ee-54a9-b091-8d2e1f609722",
 			),
@@ -135,7 +141,8 @@ var _ = DescribeTable("Positive: Get DIDDoc version", func(testCase utils.Positi
 		"can get DIDDoc version with an existent DID and versionId, and supported DIDJSON resolution type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s",
+				"http://%s/1.0/identifiers/%s/version/%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.UUIDStyleTestnetVersionId,
 			),
@@ -151,7 +158,8 @@ var _ = DescribeTable("Positive: Get DIDDoc version", func(testCase utils.Positi
 		"can get DIDDoc version with an existent DID and versionId, and supported DIDJSONLD resolution type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s",
+				"http://%s/1.0/identifiers/%s/version/%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.UUIDStyleTestnetVersionId,
 			),
@@ -167,7 +175,8 @@ var _ = DescribeTable("Positive: Get DIDDoc version", func(testCase utils.Positi
 		"can get DIDDoc version with an existent DID and versionId, and supported JSONLD resolution type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s",
+				"http://%s/1.0/identifiers/%s/version/%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.UUIDStyleTestnetVersionId,
 			),
@@ -183,7 +192,8 @@ var _ = DescribeTable("Positive: Get DIDDoc version", func(testCase utils.Positi
 		"can get DIDDoc version with an existent DID and versionId, and supported gzip encoding type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s",
+				"http://%s/1.0/identifiers/%s/version/%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.UUIDStyleTestnetVersionId,
 			),
@@ -199,7 +209,8 @@ var _ = DescribeTable("Positive: Get DIDDoc version", func(testCase utils.Positi
 		"can get DIDDoc version with an existent DID and versionId, and not supported encoding type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/version/%s",
+				"http://%s/1.0/identifiers/%s/version/%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.UUIDStyleTestnetVersionId,
 			),

--- a/tests/integration/rest/diddoc/versions/negative_test.go
+++ b/tests/integration/rest/diddoc/versions/negative_test.go
@@ -35,7 +35,8 @@ var _ = DescribeTable("Negative: Get DIDDoc versions", func(testCase utils.Negat
 		"cannot get DIDDoc versions with an existent DID, but not supported ResolutionType",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/versions",
+				"http://%s/1.0/identifiers/%s/versions",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleMainnetDid,
 			),
 			ResolutionType: string(types.JSON),
@@ -57,7 +58,8 @@ var _ = DescribeTable("Negative: Get DIDDoc versions", func(testCase utils.Negat
 		"cannot get DIDDoc versions with not existent DID and not supported ResolutionType",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/versions",
+				"http://%s/1.0/identifiers/%s/versions",
+				testconstants.SUTHost,
 				testconstants.NotExistentMainnetDid,
 			),
 			ResolutionType: string(types.JSON),
@@ -79,7 +81,8 @@ var _ = DescribeTable("Negative: Get DIDDoc versions", func(testCase utils.Negat
 		"cannot get DIDDoc versions with not existent DID",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/versions",
+				"http://%s/1.0/identifiers/%s/versions",
+				testconstants.SUTHost,
 				testconstants.NotExistentTestnetDid,
 			),
 			ResolutionType: testconstants.DefaultResolutionType,
@@ -105,7 +108,8 @@ var _ = DescribeTable("Negative: Get DIDDoc versions", func(testCase utils.Negat
 		"cannot get DIDDoc versions with invalid DID",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/versions",
+				"http://%s/1.0/identifiers/%s/versions",
+				testconstants.SUTHost,
 				testconstants.InvalidDid,
 			),
 			ResolutionType: testconstants.DefaultResolutionType,

--- a/tests/integration/rest/diddoc/versions/positive_test.go
+++ b/tests/integration/rest/diddoc/versions/positive_test.go
@@ -39,7 +39,8 @@ var _ = DescribeTable("Positive: Get DIDDoc versions", func(testCase utils.Posit
 		"can get DIDDoc versions with an existent DID",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/versions",
+				"http://%s/1.0/identifiers/%s/versions",
+				testconstants.SUTHost,
 				testconstants.IndyStyleTestnetDid,
 			),
 			ResolutionType:       testconstants.DefaultResolutionType,
@@ -54,7 +55,8 @@ var _ = DescribeTable("Positive: Get DIDDoc versions", func(testCase utils.Posit
 		"can get DIDDoc versions with an existent old 16 characters Indy style DID",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/versions",
+				"http://%s/1.0/identifiers/%s/versions",
+				testconstants.SUTHost,
 				testconstants.OldIndy16CharStyleTestnetDid,
 			),
 			ResolutionType:       testconstants.DefaultResolutionType,
@@ -69,7 +71,8 @@ var _ = DescribeTable("Positive: Get DIDDoc versions", func(testCase utils.Posit
 		"can get DIDDoc versions with an existent old 32 characters Indy style DID",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/versions",
+				"http://%s/1.0/identifiers/%s/versions",
+				testconstants.SUTHost,
 				testconstants.OldIndy32CharStyleTestnetDid,
 			),
 			ResolutionType:       testconstants.DefaultResolutionType,
@@ -84,7 +87,8 @@ var _ = DescribeTable("Positive: Get DIDDoc versions", func(testCase utils.Posit
 		"can get DIDDoc versions with an existent DID, and supported DIDJSON resolution type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/versions",
+				"http://%s/1.0/identifiers/%s/versions",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 			),
 			ResolutionType:       string(types.DIDJSON),
@@ -99,7 +103,8 @@ var _ = DescribeTable("Positive: Get DIDDoc versions", func(testCase utils.Posit
 		"can get DIDDoc version with an existent DID, and supported DIDJSONLD resolution type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/versions",
+				"http://%s/1.0/identifiers/%s/versions",
+				testconstants.SUTHost,
 				testconstants.IndyStyleTestnetDid,
 			),
 			ResolutionType:       string(types.DIDJSONLD),
@@ -114,7 +119,8 @@ var _ = DescribeTable("Positive: Get DIDDoc versions", func(testCase utils.Posit
 		"can get DIDDoc version with an existent DID, and supported JSONLD resolution type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/versions",
+				"http://%s/1.0/identifiers/%s/versions",
+				testconstants.SUTHost,
 				testconstants.IndyStyleTestnetDid,
 			),
 			ResolutionType:       string(types.JSONLD),
@@ -129,7 +135,8 @@ var _ = DescribeTable("Positive: Get DIDDoc versions", func(testCase utils.Posit
 		"can get DIDDoc version with an existent DID, and supported gzip encoding type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/versions",
+				"http://%s/1.0/identifiers/%s/versions",
+				testconstants.SUTHost,
 				testconstants.IndyStyleTestnetDid,
 			),
 			ResolutionType:       testconstants.DefaultResolutionType,
@@ -144,7 +151,8 @@ var _ = DescribeTable("Positive: Get DIDDoc versions", func(testCase utils.Posit
 		"can get DIDDoc version with an existent DID, and not supported encoding type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/versions",
+				"http://%s/1.0/identifiers/%s/versions",
+				testconstants.SUTHost,
 				testconstants.IndyStyleTestnetDid,
 			),
 			ResolutionType:     testconstants.DefaultResolutionType,

--- a/tests/integration/rest/resource/collection/negative_test.go
+++ b/tests/integration/rest/resource/collection/negative_test.go
@@ -35,7 +35,8 @@ var _ = DescribeTable("Negative: Get collection of resources", func(testCase uti
 		"cannot get collection of resources with an existent DID, but not supported ResolutionType",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/metadata",
+				"http://%s/1.0/identifiers/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleMainnetDid,
 			),
 			ResolutionType: string(types.JSON),
@@ -57,7 +58,8 @@ var _ = DescribeTable("Negative: Get collection of resources", func(testCase uti
 		"cannot get collection of resources with not existent DID and not supported ResolutionType",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/metadata",
+				"http://%s/1.0/identifiers/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.NotExistentMainnetDid,
 			),
 			ResolutionType: string(types.JSON),
@@ -79,7 +81,8 @@ var _ = DescribeTable("Negative: Get collection of resources", func(testCase uti
 		"cannot get collection of resources with not existent DID",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/metadata",
+				"http://%s/1.0/identifiers/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.NotExistentMainnetDid,
 			),
 			ResolutionType: testconstants.DefaultResolutionType,
@@ -105,7 +108,8 @@ var _ = DescribeTable("Negative: Get collection of resources", func(testCase uti
 		"cannot get collection of resources with invalid DID",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/metadata",
+				"http://%s/1.0/identifiers/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.InvalidDid,
 			),
 			ResolutionType: testconstants.DefaultResolutionType,

--- a/tests/integration/rest/resource/collection/positive_test.go
+++ b/tests/integration/rest/resource/collection/positive_test.go
@@ -39,7 +39,8 @@ var _ = DescribeTable("Positive: get collection of resources", func(testCase uti
 		"can get collection of resources with existent DID",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/metadata",
+				"http://%s/1.0/identifiers/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 			),
 			ResolutionType:       testconstants.DefaultResolutionType,
@@ -56,7 +57,8 @@ var _ = DescribeTable("Positive: get collection of resources", func(testCase uti
 		"can get collection of resources with existent old 32 characters Indy style DID",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/metadata",
+				"http://%s/1.0/identifiers/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.OldIndy32CharStyleTestnetDid,
 			),
 			ResolutionType:       testconstants.DefaultResolutionType,
@@ -71,7 +73,8 @@ var _ = DescribeTable("Positive: get collection of resources", func(testCase uti
 		"can get collection of resources with an existent DID, and supported DIDJSON resolution type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/metadata",
+				"http://%s/1.0/identifiers/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 			),
 			ResolutionType:       string(types.DIDJSON),
@@ -86,7 +89,8 @@ var _ = DescribeTable("Positive: get collection of resources", func(testCase uti
 		"can get collection of resources with an existent DID, and supported DIDJSONLD resolution type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/metadata",
+				"http://%s/1.0/identifiers/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 			),
 			ResolutionType:       string(types.DIDJSONLD),
@@ -101,7 +105,8 @@ var _ = DescribeTable("Positive: get collection of resources", func(testCase uti
 		"can get collection of resources with an existent DID, and supported JSONLD resolution type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/metadata",
+				"http://%s/1.0/identifiers/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 			),
 			ResolutionType:       string(types.JSONLD),
@@ -116,7 +121,8 @@ var _ = DescribeTable("Positive: get collection of resources", func(testCase uti
 		"can get collection of resources with an existent DID, and supported gzip encoding type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/metadata",
+				"http://%s/1.0/identifiers/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 			),
 			ResolutionType:       testconstants.DefaultResolutionType,
@@ -131,7 +137,8 @@ var _ = DescribeTable("Positive: get collection of resources", func(testCase uti
 		"can get collection of resources with an existent DID, and not supported encoding type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/metadata",
+				"http://%s/1.0/identifiers/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 			),
 			ResolutionType:     testconstants.DefaultResolutionType,

--- a/tests/integration/rest/resource/data/negative_test.go
+++ b/tests/integration/rest/resource/data/negative_test.go
@@ -35,7 +35,8 @@ var _ = DescribeTable("Negative: Get resource data", func(testCase utils.Negativ
 		"cannot get resource data with an existent DID, but not supported ResolutionType",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/resources/%s",
+				"http://%s/1.0/identifiers/%s/resources/%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleMainnetDid,
 				testconstants.ValidIdentifier,
 			),
@@ -58,7 +59,8 @@ var _ = DescribeTable("Negative: Get resource data", func(testCase utils.Negativ
 		"cannot get resource data with not existent DID and not supported ResolutionType",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/resources/%s",
+				"http://%s/1.0/identifiers/%s/resources/%s",
+				testconstants.SUTHost,
 				testconstants.NotExistentMainnetDid,
 				testconstants.ValidIdentifier,
 			),
@@ -81,7 +83,8 @@ var _ = DescribeTable("Negative: Get resource data", func(testCase utils.Negativ
 		"cannot get resource data with not existent DID and a valid resourceId",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/resources/%s",
+				"http://%s/1.0/identifiers/%s/resources/%s",
+				testconstants.SUTHost,
 				testconstants.NotExistentMainnetDid,
 				testconstants.ValidIdentifier,
 			),
@@ -108,7 +111,8 @@ var _ = DescribeTable("Negative: Get resource data", func(testCase utils.Negativ
 		"cannot get resource data with an invalid DID and not existent resourceId",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/resources/%s",
+				"http://%s/1.0/identifiers/%s/resources/%s",
+				testconstants.SUTHost,
 				testconstants.InvalidDid,
 				testconstants.ValidIdentifier,
 			),
@@ -135,7 +139,8 @@ var _ = DescribeTable("Negative: Get resource data", func(testCase utils.Negativ
 		"cannot get resource data with not existent DID and resourceId",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/resources/%s",
+				"http://%s/1.0/identifiers/%s/resources/%s",
+				testconstants.SUTHost,
 				testconstants.NotExistentTestnetDid,
 				testconstants.NotExistentIdentifier,
 			),
@@ -162,7 +167,8 @@ var _ = DescribeTable("Negative: Get resource data", func(testCase utils.Negativ
 		"cannot get resource data with an existent DID and an invalid resourceId",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/resources/%s",
+				"http://%s/1.0/identifiers/%s/resources/%s",
+				testconstants.SUTHost,
 				testconstants.IndyStyleMainnetDid,
 				testconstants.InvalidIdentifier,
 			),
@@ -185,7 +191,8 @@ var _ = DescribeTable("Negative: Get resource data", func(testCase utils.Negativ
 		"cannot get resource data with an existent old 16 characters Indy style DID and an invalid resourceId",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/resources/%s",
+				"http://%s/1.0/identifiers/%s/resources/%s",
+				testconstants.SUTHost,
 				testconstants.OldIndy16CharStyleTestnetDid,
 				testconstants.InvalidIdentifier,
 			),
@@ -208,7 +215,8 @@ var _ = DescribeTable("Negative: Get resource data", func(testCase utils.Negativ
 		"cannot get resource data with an existent old 32 characters Indy style DID and an invalid resourceId",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/resources/%s",
+				"http://%s/1.0/identifiers/%s/resources/%s",
+				testconstants.SUTHost,
 				testconstants.OldIndy32CharStyleTestnetDid,
 				testconstants.InvalidIdentifier,
 			),

--- a/tests/integration/rest/resource/data/positive_test.go
+++ b/tests/integration/rest/resource/data/positive_test.go
@@ -39,7 +39,8 @@ var _ = DescribeTable("Positive: Get resource data", func(testCase utils.Positiv
 		"can get resource data with an existent DID and existent resourceId",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/resources/%s",
+				"http://%s/1.0/identifiers/%s/resources/%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.UUIDStyleTestnetDidResourceId,
 			),
@@ -58,7 +59,8 @@ var _ = DescribeTable("Positive: Get resource data", func(testCase utils.Positiv
 		"can get resource data with an existent old 32 characters Indy style DID and existent resourceId",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/resources/%s",
+				"http://%s/1.0/identifiers/%s/resources/%s",
+				testconstants.SUTHost,
 				testconstants.OldIndy32CharStyleTestnetDid,
 				testconstants.OldIndy32CharStyleTestnetDidIdentifierResourceId,
 			),
@@ -74,7 +76,8 @@ var _ = DescribeTable("Positive: Get resource data", func(testCase utils.Positiv
 		"can get resource data with an existent DID, and supported DIDJSON resolution type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/resources/%s",
+				"http://%s/1.0/identifiers/%s/resources/%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.UUIDStyleTestnetDidResourceId,
 			),
@@ -90,7 +93,8 @@ var _ = DescribeTable("Positive: Get resource data", func(testCase utils.Positiv
 		"can get resource data with an existent DID, and supported DIDJSONLD resolution type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/resources/%s",
+				"http://%s/1.0/identifiers/%s/resources/%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.UUIDStyleTestnetDidResourceId,
 			),
@@ -106,7 +110,8 @@ var _ = DescribeTable("Positive: Get resource data", func(testCase utils.Positiv
 		"can get resource data with an existent DID, and supported JSONLD resolution type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/resources/%s",
+				"http://%s/1.0/identifiers/%s/resources/%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.UUIDStyleTestnetDidResourceId,
 			),
@@ -122,7 +127,8 @@ var _ = DescribeTable("Positive: Get resource data", func(testCase utils.Positiv
 		"can get resource data with an existent DID, and supported gzip encoding type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/resources/%s",
+				"http://%s/1.0/identifiers/%s/resources/%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.UUIDStyleTestnetDidResourceId,
 			),
@@ -138,7 +144,8 @@ var _ = DescribeTable("Positive: Get resource data", func(testCase utils.Positiv
 		"can get resource data with an existent DID, and not supported encoding type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/resources/%s",
+				"http://%s/1.0/identifiers/%s/resources/%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.UUIDStyleTestnetDidResourceId,
 			),

--- a/tests/integration/rest/resource/metadata/negative_test.go
+++ b/tests/integration/rest/resource/metadata/negative_test.go
@@ -35,7 +35,8 @@ var _ = DescribeTable("Negative: get resource metadata", func(testCase utils.Neg
 		"cannot get resource metadata with an existent DID and resourceId, but not supported ResolutionType",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/resources/%s/metadata",
+				"http://%s/1.0/identifiers/%s/resources/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleMainnetDid,
 				testconstants.ValidIdentifier,
 			),
@@ -58,7 +59,8 @@ var _ = DescribeTable("Negative: get resource metadata", func(testCase utils.Neg
 		"cannot get resource metadata with not existent DID and not supported ResolutionType",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/resources/%s/metadata",
+				"http://%s/1.0/identifiers/%s/resources/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.NotExistentMainnetDid,
 				testconstants.ValidIdentifier,
 			),
@@ -81,7 +83,8 @@ var _ = DescribeTable("Negative: get resource metadata", func(testCase utils.Neg
 		"cannot get resource metadata with not existent DID",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/resources/%s/metadata",
+				"http://%s/1.0/identifiers/%s/resources/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.NotExistentMainnetDid,
 				testconstants.ValidIdentifier,
 			),
@@ -108,7 +111,8 @@ var _ = DescribeTable("Negative: get resource metadata", func(testCase utils.Neg
 		"cannot get resource metadata with an invalid DID",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/resources/%s/metadata",
+				"http://%s/1.0/identifiers/%s/resources/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.InvalidDid,
 				testconstants.ValidIdentifier,
 			),
@@ -135,7 +139,8 @@ var _ = DescribeTable("Negative: get resource metadata", func(testCase utils.Neg
 		"cannot get resource metadata with an existent DID and not existent resourceId",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/resources/%s/metadata",
+				"http://%s/1.0/identifiers/%s/resources/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.NotExistentIdentifier,
 			),
@@ -162,7 +167,8 @@ var _ = DescribeTable("Negative: get resource metadata", func(testCase utils.Neg
 		"cannot get resource metadata with an existent old 16 characters Indy style DID and not existent resourceId",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/resources/%s/metadata",
+				"http://%s/1.0/identifiers/%s/resources/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.OldIndy16CharStyleTestnetDid,
 				testconstants.NotExistentIdentifier,
 			),
@@ -189,7 +195,8 @@ var _ = DescribeTable("Negative: get resource metadata", func(testCase utils.Neg
 		"cannot get resource metadata with an existent old 32 characters Indy style DID and not existent resourceId",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/resources/%s/metadata",
+				"http://%s/1.0/identifiers/%s/resources/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.OldIndy32CharStyleTestnetDid,
 				testconstants.NotExistentIdentifier,
 			),
@@ -216,7 +223,8 @@ var _ = DescribeTable("Negative: get resource metadata", func(testCase utils.Neg
 		"cannot get resource metadata with an existent DID and an invalid resourceId",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/resources/%s/metadata",
+				"http://%s/1.0/identifiers/%s/resources/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.IndyStyleMainnetDid,
 				testconstants.InvalidIdentifier,
 			),

--- a/tests/integration/rest/resource/metadata/positive_test.go
+++ b/tests/integration/rest/resource/metadata/positive_test.go
@@ -39,7 +39,8 @@ var _ = DescribeTable("Positive: get resource metadata", func(testCase utils.Pos
 		"can get resource metadata with existent DID and resourceId",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/resources/%s/metadata",
+				"http://%s/1.0/identifiers/%s/resources/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.UUIDStyleTestnetDidResourceId,
 			),
@@ -58,7 +59,8 @@ var _ = DescribeTable("Positive: get resource metadata", func(testCase utils.Pos
 		"can get resource metadata with existent old 32 characters Indy style DID and an existent resourceId",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/resources/%s/metadata",
+				"http://%s/1.0/identifiers/%s/resources/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.OldIndy32CharStyleTestnetDid,
 				testconstants.OldIndy32CharStyleTestnetDidIdentifierResourceId,
 			),
@@ -74,7 +76,8 @@ var _ = DescribeTable("Positive: get resource metadata", func(testCase utils.Pos
 		"can get resource metadata with an existent DID, and supported DIDJSON resolution type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/resources/%s/metadata",
+				"http://%s/1.0/identifiers/%s/resources/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.UUIDStyleTestnetDidResourceId,
 			),
@@ -90,7 +93,8 @@ var _ = DescribeTable("Positive: get resource metadata", func(testCase utils.Pos
 		"can get resource metadata with an existent DID, and supported DIDJSONLD resolution type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/resources/%s/metadata",
+				"http://%s/1.0/identifiers/%s/resources/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.UUIDStyleTestnetDidResourceId,
 			),
@@ -106,7 +110,8 @@ var _ = DescribeTable("Positive: get resource metadata", func(testCase utils.Pos
 		"can get DIDDoc version with an existent DID, and supported JSONLD resolution type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/resources/%s/metadata",
+				"http://%s/1.0/identifiers/%s/resources/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.UUIDStyleTestnetDidResourceId,
 			),
@@ -122,7 +127,8 @@ var _ = DescribeTable("Positive: get resource metadata", func(testCase utils.Pos
 		"can get DIDDoc version with an existent DID, and supported gzip encoding type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/resources/%s/metadata",
+				"http://%s/1.0/identifiers/%s/resources/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.UUIDStyleTestnetDidResourceId,
 			),
@@ -138,7 +144,8 @@ var _ = DescribeTable("Positive: get resource metadata", func(testCase utils.Pos
 		"can get DIDDoc version with an existent DID, and supported gzip encoding type",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s/resources/%s/metadata",
+				"http://%s/1.0/identifiers/%s/resources/%s/metadata",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.UUIDStyleTestnetDidResourceId,
 			),

--- a/tests/integration/rest/resource/query/common_positive_test.go
+++ b/tests/integration/rest/resource/query/common_positive_test.go
@@ -36,7 +36,8 @@ var _ = DescribeTable("Positive: request with common query parameters", func(tes
 		"can get resource with and existent versionId and resourceCollectionId",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionId=%s&resourceCollectionId=%s",
+				"http://%s/1.0/identifiers/%s?versionId=%s&resourceCollectionId=%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.UUIDStyleTestnetVersionId,
 				testconstants.UUIDStyleTestnetId,
@@ -51,7 +52,8 @@ var _ = DescribeTable("Positive: request with common query parameters", func(tes
 		"can get resource with an existent versionId and resourceId",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionId=%s&resourceId=%s",
+				"http://%s/1.0/identifiers/%s?versionId=%s&resourceId=%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.UUIDStyleTestnetVersionId,
 				testconstants.UUIDStyleTestnetDidResourceId,
@@ -66,7 +68,8 @@ var _ = DescribeTable("Positive: request with common query parameters", func(tes
 		"can get resource with and existent versionTime and resourceCollectionId",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionTime=%s&resourceCollectionId=%s",
+				"http://%s/1.0/identifiers/%s?versionTime=%s&resourceCollectionId=%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				"2023-01-25T11:58:11Z",
 				testconstants.UUIDStyleTestnetId,
@@ -81,7 +84,8 @@ var _ = DescribeTable("Positive: request with common query parameters", func(tes
 		"can get resource with an existent versionTime and resourceId",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionTime=%s&resourceId=%s",
+				"http://%s/1.0/identifiers/%s?versionTime=%s&resourceId=%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				"2023-01-25T11:58:11Z",
 				testconstants.UUIDStyleTestnetDidResourceId,
@@ -96,7 +100,8 @@ var _ = DescribeTable("Positive: request with common query parameters", func(tes
 		"can get resource with an existent versionId, versionTime, resourceCollection, resourceId",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?versionId=%s&versionTime=%s&resourceCollectionId=%s&resourceId=%s",
+				"http://%s/1.0/identifiers/%s?versionId=%s&versionTime=%s&resourceCollectionId=%s&resourceId=%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.UUIDStyleTestnetVersionId,
 				"2023-01-25T11:58:11Z",
@@ -113,7 +118,8 @@ var _ = DescribeTable("Positive: request with common query parameters", func(tes
 		"can get resource with an existent resourceId and resourceVersionTime",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceId=%s&resourceVersionTime=%s",
+				"http://%s/1.0/identifiers/%s?resourceId=%s&resourceVersionTime=%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.UUIDStyleTestnetDidResourceId,
 				"2023-01-25T12:08:40Z",
@@ -128,7 +134,8 @@ var _ = DescribeTable("Positive: request with common query parameters", func(tes
 		"can get resource with an existent resourceCollectionId, resourceId, resourceName, resourceType, resourceVersion",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceCollectionId=%s&resourceId=%s&resourceName=%s&resourceType=%s&resourceVersion=%s",
+				"http://%s/1.0/identifiers/%s?resourceCollectionId=%s&resourceId=%s&resourceName=%s&resourceType=%s&resourceVersion=%s",
+				testconstants.SUTHost,
 				"did:cheqd:testnet:0a5b94d0-a417-48ed-a6f5-4abc9e95888d",
 				"0a5b94d0-a417-48ed-a6f5-4abc9e95888d",
 				"ef344b53-f2db-44bd-9df3-01259c178704",
@@ -146,7 +153,8 @@ var _ = DescribeTable("Positive: request with common query parameters", func(tes
 		"can get resource with an existent resourceCollectionId, resourceId, resourceName, resourceType, resourceVersion, resourceVersionTime",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceCollectionId=%s&resourceId=%s&resourceName=%s&resourceType=%s&resourceVersion=%s&resourceVersionTime=%s",
+				"http://%s/1.0/identifiers/%s?resourceCollectionId=%s&resourceId=%s&resourceName=%s&resourceType=%s&resourceVersion=%s&resourceVersionTime=%s",
+				testconstants.SUTHost,
 				"did:cheqd:testnet:0a5b94d0-a417-48ed-a6f5-4abc9e95888d",
 				"0a5b94d0-a417-48ed-a6f5-4abc9e95888d",
 				"ef344b53-f2db-44bd-9df3-01259c178704",

--- a/tests/integration/rest/resource/query/resource_checksum/negative_test.go
+++ b/tests/integration/rest/resource/query/resource_checksum/negative_test.go
@@ -36,7 +36,8 @@ var _ = DescribeTable("Negative: Get Resource with checksum query", func(testCas
 		"cannot get resource with not existent checksum query parameter",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?checksum=%s",
+				"http://%s/1.0/identifiers/%s?checksum=%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				"ffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
 			),
@@ -63,7 +64,8 @@ var _ = DescribeTable("Negative: Get Resource with checksum query", func(testCas
 		"cannot get resource with an invalid checksum query parameter",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?checksum=%s",
+				"http://%s/1.0/identifiers/%s?checksum=%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				"abcdefghijklmnopqrstuvwxy",
 			),

--- a/tests/integration/rest/resource/query/resource_checksum/positive_test.go
+++ b/tests/integration/rest/resource/query/resource_checksum/positive_test.go
@@ -37,7 +37,8 @@ var _ = DescribeTable("Positive: Get Resource with checksum query", func(testCas
 		"can get resource with an existent checksum query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?checksum=%s",
+				"http://%s/1.0/identifiers/%s?checksum=%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				"cffd829b06797f85407be9353056db722ca3eca0c05ab0462a42d30f19cdef09",
 			),
@@ -54,7 +55,8 @@ var _ = DescribeTable("Positive: Get Resource with checksum query", func(testCas
 		"can get resource with an old 32 characters INDY style DID and an existent checksum query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?checksum=%s",
+				"http://%s/1.0/identifiers/%s?checksum=%s",
+				testconstants.SUTHost,
 				testconstants.OldIndy32CharStyleTestnetDid,
 				"657e37a833f139fc8f58b115174b2297223a2d98316a78ce8d49d60467d8913d",
 			),

--- a/tests/integration/rest/resource/query/resource_collection_id/negative_test.go
+++ b/tests/integration/rest/resource/query/resource_collection_id/negative_test.go
@@ -35,7 +35,8 @@ var _ = DescribeTable("Negative: Get Collection of Resources with collectionId q
 		"cannot get collection of resources with not existent collectionId query parameter",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?collectionId=%s",
+				"http://%s/1.0/identifiers/%s?collectionId=%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.NotExistentIdentifier,
 			),
@@ -62,7 +63,8 @@ var _ = DescribeTable("Negative: Get Collection of Resources with collectionId q
 		"cannot get collection of resources with an invalid collectionId query parameter",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?collectionId=%s",
+				"http://%s/1.0/identifiers/%s?collectionId=%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.InvalidIdentifier,
 			),

--- a/tests/integration/rest/resource/query/resource_collection_id/positive_test.go
+++ b/tests/integration/rest/resource/query/resource_collection_id/positive_test.go
@@ -37,7 +37,8 @@ var _ = DescribeTable("Positive: Get Collection of Resources with collectionId q
 		"can get collection of resources with an existent collectionId query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceCollectionId=%s",
+				"http://%s/1.0/identifiers/%s?resourceCollectionId=%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.UUIDStyleTestnetId,
 			),
@@ -54,7 +55,8 @@ var _ = DescribeTable("Positive: Get Collection of Resources with collectionId q
 		"can get collection of resources with an old 32 characters INDY style DID and an existent collectionId query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceCollectionId=%s",
+				"http://%s/1.0/identifiers/%s?resourceCollectionId=%s",
+				testconstants.SUTHost,
 				testconstants.OldIndy32CharStyleTestnetDid,
 				"3KpiDD6Hxs4i2G7FtpiGhu",
 			),

--- a/tests/integration/rest/resource/query/resource_id/negative_test.go
+++ b/tests/integration/rest/resource/query/resource_id/negative_test.go
@@ -36,7 +36,8 @@ var _ = DescribeTable("Negative: Get Resource with resourceId query", func(testC
 		"cannot get resource with not existent resourceId query",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceId=%s",
+				"http://%s/1.0/identifiers/%s?resourceId=%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.NotExistentIdentifier,
 			),
@@ -63,7 +64,8 @@ var _ = DescribeTable("Negative: Get Resource with resourceId query", func(testC
 		"cannot get resource with an invalid resourceId query",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceId=%s",
+				"http://%s/1.0/identifiers/%s?resourceId=%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.InvalidIdentifier,
 			),

--- a/tests/integration/rest/resource/query/resource_id/positive_test.go
+++ b/tests/integration/rest/resource/query/resource_id/positive_test.go
@@ -37,7 +37,8 @@ var _ = DescribeTable("Positive: Get Resource with resourceId query", func(testC
 		"can get resource with an existent resourceId query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceId=%s",
+				"http://%s/1.0/identifiers/%s?resourceId=%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				testconstants.UUIDStyleTestnetDidResourceId,
 			),
@@ -54,7 +55,8 @@ var _ = DescribeTable("Positive: Get Resource with resourceId query", func(testC
 		"can get collection of resources with an old 32 characters INDY style DID and an existent resourceId query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceId=%s",
+				"http://%s/1.0/identifiers/%s?resourceId=%s",
+				testconstants.SUTHost,
 				testconstants.OldIndy32CharStyleTestnetDid,
 				testconstants.OldIndy32CharStyleTestnetDidIdentifierResourceId,
 			),

--- a/tests/integration/rest/resource/query/resource_metadata/negative_test.go
+++ b/tests/integration/rest/resource/query/resource_metadata/negative_test.go
@@ -36,7 +36,8 @@ var _ = DescribeTable("Negative: Get Resource Metadata with resourceMetadata que
 		"cannot get resource metadata with not supported resourceMetadata query parameter value",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceMetadata=xyz",
+				"http://%s/1.0/identifiers/%s?resourceMetadata=xyz",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 			),
 			ResolutionType: string(types.DIDJSONLD),

--- a/tests/integration/rest/resource/query/resource_metadata/positive_test.go
+++ b/tests/integration/rest/resource/query/resource_metadata/positive_test.go
@@ -37,7 +37,8 @@ var _ = DescribeTable("Positive: Get Resource Metadata with resourceMetadata que
 		"can get resource metadata with resourceMetadata=true query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceMetadata=true",
+				"http://%s/1.0/identifiers/%s?resourceMetadata=true",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 			),
 			ResolutionType:     testconstants.DefaultResolutionType,
@@ -50,7 +51,8 @@ var _ = DescribeTable("Positive: Get Resource Metadata with resourceMetadata que
 	// 	"can get resource metadata with resourceMetadata=false query parameter",
 	// 	utils.PositiveTestCase{
 	// 		DidURL: fmt.Sprintf(
-	// 			"http://localhost:8080/1.0/identifiers/%s?resourceMetadata=false",
+	// 			"http://%s/1.0/identifiers/%s?resourceMetadata=false",
+	//			testconstants.SUTHost,
 	// 			testconstants.UUIDStyleTestnetDid,
 	// 		),
 	// 		ResolutionType:     testconstants.DefaultResolutionType,
@@ -63,7 +65,8 @@ var _ = DescribeTable("Positive: Get Resource Metadata with resourceMetadata que
 		"can get collection of resources with an old 32 characters INDY style DID and resourceMetadata query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceMetadata=true",
+				"http://%s/1.0/identifiers/%s?resourceMetadata=true",
+				testconstants.SUTHost,
 				testconstants.OldIndy32CharStyleTestnetDid,
 			),
 			ResolutionType:     testconstants.DefaultResolutionType,

--- a/tests/integration/rest/resource/query/resource_name/negative_test.go
+++ b/tests/integration/rest/resource/query/resource_name/negative_test.go
@@ -36,7 +36,8 @@ var _ = DescribeTable("Negative: Get Resource with resourceName query", func(tes
 		"cannot get resource with not existent resourceName query parameter",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceName=demo",
+				"http://%s/1.0/identifiers/%s?resourceName=demo",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 			),
 			ResolutionType: string(types.DIDJSONLD),

--- a/tests/integration/rest/resource/query/resource_name/positive_test.go
+++ b/tests/integration/rest/resource/query/resource_name/positive_test.go
@@ -37,7 +37,8 @@ var _ = DescribeTable("Positive: Get Resource with resourceName query", func(tes
 		"can get resource with an existent resourceName query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceName=%s",
+				"http://%s/1.0/identifiers/%s?resourceName=%s",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				"ResourceName",
 			),
@@ -54,7 +55,8 @@ var _ = DescribeTable("Positive: Get Resource with resourceName query", func(tes
 		"can get resource with an old 32 characters INDY style DID and resourceName query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceName=%s",
+				"http://%s/1.0/identifiers/%s?resourceName=%s",
+				testconstants.SUTHost,
 				testconstants.OldIndy32CharStyleTestnetDid,
 				"FaberCollege301071f2-314d-49e4-8e65-393586e5e05a",
 			),

--- a/tests/integration/rest/resource/query/resource_type/negative_test.go
+++ b/tests/integration/rest/resource/query/resource_type/negative_test.go
@@ -36,7 +36,8 @@ var _ = DescribeTable("Negative: Get Resource with resourceType query", func(tes
 		"cannot get resource with not existent resourceType query parameter",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceType=xyz",
+				"http://%s/1.0/identifiers/%s?resourceType=xyz",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 			),
 			ResolutionType: string(types.DIDJSONLD),

--- a/tests/integration/rest/resource/query/resource_type/positive_test.go
+++ b/tests/integration/rest/resource/query/resource_type/positive_test.go
@@ -39,7 +39,8 @@ var _ = DescribeTable("Positive: Get Resource with resourceType query", func(tes
 		"can get resource with an existent resourceType query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceType=%s",
+				"http://%s/1.0/identifiers/%s?resourceType=%s",
+				testconstants.SUTHost,
 				SeveralResourcesDID,
 				"TrustEstablishment",
 			),
@@ -56,7 +57,8 @@ var _ = DescribeTable("Positive: Get Resource with resourceType query", func(tes
 		"can get resource with an old 32 characters INDY style DID and resourceType query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceType=%s",
+				"http://%s/1.0/identifiers/%s?resourceType=%s",
+				testconstants.SUTHost,
 				testconstants.OldIndy32CharStyleTestnetDid,
 				"CL-Schema",
 			),

--- a/tests/integration/rest/resource/query/resource_version/negative_test.go
+++ b/tests/integration/rest/resource/query/resource_version/negative_test.go
@@ -36,7 +36,8 @@ var _ = DescribeTable("Negative: Get Resource with resourceVersion query", func(
 		"cannot get resource with not existent resourceVersion query parameter",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceVersion=xyz",
+				"http://%s/1.0/identifiers/%s?resourceVersion=xyz",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 			),
 			ResolutionType: string(types.DIDJSONLD),

--- a/tests/integration/rest/resource/query/resource_version/positive_test.go
+++ b/tests/integration/rest/resource/query/resource_version/positive_test.go
@@ -39,7 +39,8 @@ var _ = DescribeTable("Positive: Get Resource with resourceVersion query", func(
 		"can get resource with an existent resourceVersion query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceVersion=1.0",
+				"http://%s/1.0/identifiers/%s?resourceVersion=1.0",
+				testconstants.SUTHost,
 				severalResourcesDID,
 			),
 			ResolutionType:     testconstants.DefaultResolutionType,

--- a/tests/integration/rest/resource/query/resource_version_time/negative_test.go
+++ b/tests/integration/rest/resource/query/resource_version_time/negative_test.go
@@ -37,7 +37,8 @@ var _ = DescribeTable("Negative: Get Collection of Resources with resourceVersio
 		"cannot get collection of resources with not existent resourceVersionTime query parameter",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceVersionTime=%s&resourceMetadata=true",
+				"http://%s/1.0/identifiers/%s?resourceVersionTime=%s&resourceMetadata=true",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				"2023-01-25T12:04:51Z",
 			),
@@ -64,7 +65,8 @@ var _ = DescribeTable("Negative: Get Collection of Resources with resourceVersio
 		"cannot get collection of resources with not supported format of resourceVersionTime query parameter",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceVersionTime=%s&resourceMetadata=true",
+				"http://%s/1.0/identifiers/%s?resourceVersionTime=%s&resourceMetadata=true",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				url.QueryEscape("06/03/2023 09:36:56"),
 			),
@@ -91,7 +93,8 @@ var _ = DescribeTable("Negative: Get Collection of Resources with resourceVersio
 		"cannot get collection of resources with an invalid resourceVersionTime query parameter",
 		utils.NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceVersionTime=xyz",
+				"http://%s/1.0/identifiers/%s?resourceVersionTime=xyz",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 			),
 			ResolutionType: string(types.DIDJSONLD),

--- a/tests/integration/rest/resource/query/resource_version_time/positive_test.go
+++ b/tests/integration/rest/resource/query/resource_version_time/positive_test.go
@@ -41,7 +41,8 @@ var _ = DescribeTable("Positive: Get Collection of Resources with resourceVersio
 		"can get resource with an old 32 characters INDY style DID and resourceVersionTime query parameter",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceVersionTime=%s&resourceMetadata=true",
+				"http://%s/1.0/identifiers/%s?resourceVersionTime=%s&resourceMetadata=true",
+				testconstants.SUTHost,
 				testconstants.OldIndy32CharStyleTestnetDid,
 				"2022-10-12T08:57:31Z",
 			),
@@ -55,7 +56,8 @@ var _ = DescribeTable("Positive: Get Collection of Resources with resourceVersio
 		"can get collection of resources with an existent resourceVersionTime query parameter (Layout format)",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceVersionTime=%s&resourceMetadata=true",
+				"http://%s/1.0/identifiers/%s?resourceVersionTime=%s&resourceMetadata=true",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				url.QueryEscape("01/25 00:08:40PM '23 +0000"),
 			),
@@ -69,7 +71,8 @@ var _ = DescribeTable("Positive: Get Collection of Resources with resourceVersio
 		"can get collection of resources with an existent resourceVersionTime query parameter (ANSIC format)",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceVersionTime=%s&resourceMetadata=true",
+				"http://%s/1.0/identifiers/%s?resourceVersionTime=%s&resourceMetadata=true",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				url.QueryEscape("Wed Jan 25 12:08:40 2023"),
 			),
@@ -83,7 +86,8 @@ var _ = DescribeTable("Positive: Get Collection of Resources with resourceVersio
 		"can get collection of resources with an existent resourceVersionTime query parameter (UnixDate format)",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceVersionTime=%s&resourceMetadata=true",
+				"http://%s/1.0/identifiers/%s?resourceVersionTime=%s&resourceMetadata=true",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				url.QueryEscape("Wed Jan 25 12:08:40 UTC 2023"),
 			),
@@ -97,7 +101,8 @@ var _ = DescribeTable("Positive: Get Collection of Resources with resourceVersio
 		"can get collection of resources with an existent resourceVersionTime query parameter (RubyDate format)",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceVersionTime=%s&resourceMetadata=true",
+				"http://%s/1.0/identifiers/%s?resourceVersionTime=%s&resourceMetadata=true",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				url.QueryEscape("Wed Jan 25 12:08:40 +0000 2023"),
 			),
@@ -111,7 +116,8 @@ var _ = DescribeTable("Positive: Get Collection of Resources with resourceVersio
 		"can get collection of resources with an existent resourceVersionTime query parameter (RFC822 format)",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceVersionTime=%s&resourceMetadata=true",
+				"http://%s/1.0/identifiers/%s?resourceVersionTime=%s&resourceMetadata=true",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				url.QueryEscape("25 Jan 23 12:09 UTC"),
 			),
@@ -125,7 +131,8 @@ var _ = DescribeTable("Positive: Get Collection of Resources with resourceVersio
 		"can get collection of resources with an existent resourceVersionTime query parameter (RFC822Z format)",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceVersionTime=%s&resourceMetadata=true",
+				"http://%s/1.0/identifiers/%s?resourceVersionTime=%s&resourceMetadata=true",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				url.QueryEscape("25 Jan 23 12:09 +0000"),
 			),
@@ -139,7 +146,8 @@ var _ = DescribeTable("Positive: Get Collection of Resources with resourceVersio
 		"can get collection of resources with an existent resourceVersionTime query parameter (RFC850 format)",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceVersionTime=%s&resourceMetadata=true",
+				"http://%s/1.0/identifiers/%s?resourceVersionTime=%s&resourceMetadata=true",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				url.QueryEscape("Wednesday, 25-Jan-23 12:08:40 UTC"),
 			),
@@ -153,7 +161,8 @@ var _ = DescribeTable("Positive: Get Collection of Resources with resourceVersio
 		"can get collection of resources with an existent resourceVersionTime query parameter (RFC1123 format)",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceVersionTime=%s&resourceMetadata=true",
+				"http://%s/1.0/identifiers/%s?resourceVersionTime=%s&resourceMetadata=true",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				url.QueryEscape("Wed, 25 Jan 2023 12:08:40 UTC"),
 			),
@@ -167,7 +176,8 @@ var _ = DescribeTable("Positive: Get Collection of Resources with resourceVersio
 		"can get collection of resources with an existent resourceVersionTime query parameter (RFC1123Z format)",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceVersionTime=%s&resourceMetadata=true",
+				"http://%s/1.0/identifiers/%s?resourceVersionTime=%s&resourceMetadata=true",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				url.QueryEscape("Wed, 25 Jan 2023 12:08:40 +0000"),
 			),
@@ -181,7 +191,8 @@ var _ = DescribeTable("Positive: Get Collection of Resources with resourceVersio
 		"can get collection of resources with an existent resourceVersionTime query parameter (RFC3339 format)",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceVersionTime=%s&resourceMetadata=true",
+				"http://%s/1.0/identifiers/%s?resourceVersionTime=%s&resourceMetadata=true",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				"2023-01-25T12:08:40Z",
 			),
@@ -195,7 +206,8 @@ var _ = DescribeTable("Positive: Get Collection of Resources with resourceVersio
 		"can get collection of resources with an existent resourceVersionTime query parameter (RFC3339Nano format)",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceVersionTime=%s&resourceMetadata=true",
+				"http://%s/1.0/identifiers/%s?resourceVersionTime=%s&resourceMetadata=true",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				"2023-01-25T12:08:40.0Z",
 			),
@@ -209,7 +221,8 @@ var _ = DescribeTable("Positive: Get Collection of Resources with resourceVersio
 		"can get collection of resources with an existent resourceVersionTime query parameter (DateTime format)",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceVersionTime=%s&resourceMetadata=true",
+				"http://%s/1.0/identifiers/%s?resourceVersionTime=%s&resourceMetadata=true",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				url.QueryEscape("2023-01-25 12:08:40"),
 			),
@@ -223,7 +236,8 @@ var _ = DescribeTable("Positive: Get Collection of Resources with resourceVersio
 		"can get collection of resources with an existent resourceVersionTime query parameter (DateOnly format)",
 		utils.PositiveTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?resourceVersionTime=%s&resourceMetadata=true",
+				"http://%s/1.0/identifiers/%s?resourceVersionTime=%s&resourceMetadata=true",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 				"2023-01-26",
 			),

--- a/tests/integration/rest/support_query_negative_test.go
+++ b/tests/integration/rest/support_query_negative_test.go
@@ -35,7 +35,8 @@ var _ = DescribeTable("", func(testCase NegativeTestCase) {
 		"cannot get resolution result with an invalid query",
 		NegativeTestCase{
 			DidURL: fmt.Sprintf(
-				"http://localhost:8080/1.0/identifiers/%s?invalid_parameter=invalid_value",
+				"http://%s/1.0/identifiers/%s?invalid_parameter=invalid_value",
+				testconstants.SUTHost,
 				testconstants.UUIDStyleTestnetDid,
 			),
 			ResolutionType: testconstants.DefaultResolutionType,


### PR DESCRIPTION
This is a very mechanical/repetitive, although large change to the integration test suite.

**Problem Addressed:**  
The integration tests hardcode the host portion of all test Cheqd DID URLs to be localhost:8080.  Whilst this works when running on a developers local machine and on GitHub it doesn't work for Gitlab pipelines which need a docker-in-docker container addressed as 'docker:8080'.  Additionally with this set of changes it will be possible to run the integration tests against any publicly accessible/deployed cheqd resolver which could be useful in diagnosing field issues/anomalies.

**Solution submitted**
This change introduces an integration testing environment string variable called `SUT_HOST_ADDRESS`.  
If the environment variable is set then the `SUTHost` test constant is set to that value in `tests/constants/constants.go`. If the environment variable is NOT set then the default behaviour is maintained with `SUTHost` being set to `localhost:8080`.
All current integration tests were changed to use `SUTHost` when creating DidURL using fmt.Sprintf() in place of the hardcoded `localhost:8080`