### PR TITLE
feat: Return metadata in contentMetadata key

### DIFF
--- a/services/resource_dereference_service.go
+++ b/services/resource_dereference_service.go
@@ -6,7 +6,6 @@ import (
 
 	"strings"
 
-	resourceTypes "github.com/cheqd/cheqd-node/api/v2/cheqd/resource/v2"
 	"github.com/cheqd/did-resolver/types"
 )
 
@@ -36,9 +35,9 @@ func (rds ResourceService) DereferenceResourceMetadata(did string, resourceId st
 		context = types.ResolutionSchemaJSONLD
 	}
 
-	contentStream := types.NewDereferencedResourceListStruct(did, []*resourceTypes.Metadata{resource.Metadata})
+	metadata := types.NewDereferencedResource(did, resource.Metadata)
 
-	return &types.ResourceDereferencing{Context: context, ContentStream: contentStream, DereferencingMetadata: dereferenceMetadata}, nil
+	return &types.ResourceDereferencing{Context: context, Metadata: metadata, DereferencingMetadata: dereferenceMetadata}, nil
 }
 
 func (rds ResourceService) DereferenceCollectionResources(did string, contentType types.ContentType) (*types.ResourceDereferencing, *types.IdentityError) {

--- a/tests/integration/rest/resource/metadata/negative_test.go
+++ b/tests/integration/rest/resource/metadata/negative_test.go
@@ -23,12 +23,12 @@ var _ = DescribeTable("Negative: get resource metadata", func(testCase utils.Neg
 		Get(testCase.DidURL)
 	Expect(err).To(BeNil())
 
-	var receivedDidDereferencing utils.DereferencingResult
-	Expect(json.Unmarshal(resp.Body(), &receivedDidDereferencing)).To(BeNil())
+	var receivedResourceDereferencing utils.ResourceDereferencingResult
+	Expect(json.Unmarshal(resp.Body(), &receivedResourceDereferencing)).To(BeNil())
 	Expect(testCase.ExpectedStatusCode).To(Equal(resp.StatusCode()))
 
-	expectedDidDereferencing := testCase.ExpectedResult.(utils.DereferencingResult)
-	utils.AssertDidDereferencing(expectedDidDereferencing, receivedDidDereferencing)
+	expectedResourceDereferencing := testCase.ExpectedResult.(utils.ResourceDereferencingResult)
+	utils.AssertResourceMetadata(expectedResourceDereferencing, receivedResourceDereferencing)
 },
 
 	Entry(
@@ -41,7 +41,7 @@ var _ = DescribeTable("Negative: get resource metadata", func(testCase utils.Neg
 				testconstants.ValidIdentifier,
 			),
 			ResolutionType: string(types.JSON),
-			ExpectedResult: utils.DereferencingResult{
+			ExpectedResult: utils.ResourceDereferencingResult{
 				Context: "",
 				DereferencingMetadata: types.DereferencingMetadata{
 					ContentType:     types.JSON,
@@ -49,7 +49,7 @@ var _ = DescribeTable("Negative: get resource metadata", func(testCase utils.Neg
 					DidProperties:   types.DidProperties{},
 				},
 				ContentStream: nil,
-				Metadata:      types.ResolutionDidDocMetadata{},
+				Metadata:      &types.DereferencedResource{},
 			},
 			ExpectedStatusCode: errors.RepresentationNotSupportedHttpCode,
 		},
@@ -65,7 +65,7 @@ var _ = DescribeTable("Negative: get resource metadata", func(testCase utils.Neg
 				testconstants.ValidIdentifier,
 			),
 			ResolutionType: string(types.JSON),
-			ExpectedResult: utils.DereferencingResult{
+			ExpectedResult: utils.ResourceDereferencingResult{
 				Context: "",
 				DereferencingMetadata: types.DereferencingMetadata{
 					ContentType:     types.JSON,
@@ -73,7 +73,7 @@ var _ = DescribeTable("Negative: get resource metadata", func(testCase utils.Neg
 					DidProperties:   types.DidProperties{},
 				},
 				ContentStream: nil,
-				Metadata:      types.ResolutionDidDocMetadata{},
+				Metadata:      &types.DereferencedResource{},
 			},
 			ExpectedStatusCode: errors.RepresentationNotSupportedHttpCode,
 		},
@@ -89,7 +89,7 @@ var _ = DescribeTable("Negative: get resource metadata", func(testCase utils.Neg
 				testconstants.ValidIdentifier,
 			),
 			ResolutionType: testconstants.DefaultResolutionType,
-			ExpectedResult: utils.DereferencingResult{
+			ExpectedResult: utils.ResourceDereferencingResult{
 				Context: "",
 				DereferencingMetadata: types.DereferencingMetadata{
 					ContentType:     types.DIDJSONLD,
@@ -101,7 +101,7 @@ var _ = DescribeTable("Negative: get resource metadata", func(testCase utils.Neg
 					},
 				},
 				ContentStream: nil,
-				Metadata:      types.ResolutionDidDocMetadata{},
+				Metadata:      &types.DereferencedResource{},
 			},
 			ExpectedStatusCode: errors.NotFoundHttpCode,
 		},
@@ -117,7 +117,7 @@ var _ = DescribeTable("Negative: get resource metadata", func(testCase utils.Neg
 				testconstants.ValidIdentifier,
 			),
 			ResolutionType: testconstants.DefaultResolutionType,
-			ExpectedResult: utils.DereferencingResult{
+			ExpectedResult: utils.ResourceDereferencingResult{
 				Context: "",
 				DereferencingMetadata: types.DereferencingMetadata{
 					ContentType:     types.DIDJSONLD,
@@ -129,7 +129,7 @@ var _ = DescribeTable("Negative: get resource metadata", func(testCase utils.Neg
 					},
 				},
 				ContentStream: nil,
-				Metadata:      types.ResolutionDidDocMetadata{},
+				Metadata:      &types.DereferencedResource{},
 			},
 			ExpectedStatusCode: errors.MethodNotSupportedHttpCode,
 		},
@@ -145,7 +145,7 @@ var _ = DescribeTable("Negative: get resource metadata", func(testCase utils.Neg
 				testconstants.NotExistentIdentifier,
 			),
 			ResolutionType: testconstants.DefaultResolutionType,
-			ExpectedResult: utils.DereferencingResult{
+			ExpectedResult: utils.ResourceDereferencingResult{
 				Context: "",
 				DereferencingMetadata: types.DereferencingMetadata{
 					ContentType:     types.DIDJSONLD,
@@ -157,7 +157,7 @@ var _ = DescribeTable("Negative: get resource metadata", func(testCase utils.Neg
 					},
 				},
 				ContentStream: nil,
-				Metadata:      types.ResolutionDidDocMetadata{},
+				Metadata:      &types.DereferencedResource{},
 			},
 			ExpectedStatusCode: errors.NotFoundHttpCode,
 		},
@@ -173,7 +173,7 @@ var _ = DescribeTable("Negative: get resource metadata", func(testCase utils.Neg
 				testconstants.NotExistentIdentifier,
 			),
 			ResolutionType: testconstants.DefaultResolutionType,
-			ExpectedResult: utils.DereferencingResult{
+			ExpectedResult: utils.ResourceDereferencingResult{
 				Context: "",
 				DereferencingMetadata: types.DereferencingMetadata{
 					ContentType:     types.DIDJSONLD,
@@ -185,7 +185,7 @@ var _ = DescribeTable("Negative: get resource metadata", func(testCase utils.Neg
 					},
 				},
 				ContentStream: nil,
-				Metadata:      types.ResolutionDidDocMetadata{},
+				Metadata:      &types.DereferencedResource{},
 			},
 			ExpectedStatusCode: errors.NotFoundHttpCode,
 		},
@@ -201,7 +201,7 @@ var _ = DescribeTable("Negative: get resource metadata", func(testCase utils.Neg
 				testconstants.NotExistentIdentifier,
 			),
 			ResolutionType: testconstants.DefaultResolutionType,
-			ExpectedResult: utils.DereferencingResult{
+			ExpectedResult: utils.ResourceDereferencingResult{
 				Context: "",
 				DereferencingMetadata: types.DereferencingMetadata{
 					ContentType:     types.DIDJSONLD,
@@ -213,7 +213,7 @@ var _ = DescribeTable("Negative: get resource metadata", func(testCase utils.Neg
 					},
 				},
 				ContentStream: nil,
-				Metadata:      types.ResolutionDidDocMetadata{},
+				Metadata:      &types.DereferencedResource{},
 			},
 			ExpectedStatusCode: errors.NotFoundHttpCode,
 		},
@@ -229,7 +229,7 @@ var _ = DescribeTable("Negative: get resource metadata", func(testCase utils.Neg
 				testconstants.InvalidIdentifier,
 			),
 			ResolutionType: testconstants.DefaultResolutionType,
-			ExpectedResult: utils.DereferencingResult{
+			ExpectedResult: utils.ResourceDereferencingResult{
 				Context: "",
 				DereferencingMetadata: types.DereferencingMetadata{
 					ContentType:     types.DIDJSONLD,
@@ -237,7 +237,7 @@ var _ = DescribeTable("Negative: get resource metadata", func(testCase utils.Neg
 					DidProperties:   types.DidProperties{},
 				},
 				ContentStream: nil,
-				Metadata:      types.ResolutionDidDocMetadata{},
+				Metadata:      &types.DereferencedResource{},
 			},
 			ExpectedStatusCode: errors.InvalidDidUrlHttpCode,
 		},

--- a/tests/integration/rest/resource/metadata/positive_test.go
+++ b/tests/integration/rest/resource/metadata/positive_test.go
@@ -24,15 +24,15 @@ var _ = DescribeTable("Positive: get resource metadata", func(testCase utils.Pos
 		Get(testCase.DidURL)
 	Expect(err).To(BeNil())
 
-	var receivedDidDereferencing utils.DereferencingResult
-	Expect(json.Unmarshal(resp.Body(), &receivedDidDereferencing)).To(BeNil())
+	var receivedResourceDereferencing utils.ResourceDereferencingResult
+	Expect(json.Unmarshal(resp.Body(), &receivedResourceDereferencing)).To(BeNil())
 	Expect(testCase.ExpectedStatusCode).To(Equal(resp.StatusCode()))
 
-	var expectedDidDereferencing utils.DereferencingResult
-	Expect(utils.ConvertJsonFileToType(testCase.ExpectedJSONPath, &expectedDidDereferencing)).To(BeNil())
+	var expectedResourceDereferencing utils.ResourceDereferencingResult
+	Expect(utils.ConvertJsonFileToType(testCase.ExpectedJSONPath, &expectedResourceDereferencing)).To(BeNil())
 
 	Expect(testCase.ExpectedEncodingType).To(Equal(resp.Header().Get("Content-Encoding")))
-	utils.AssertDidDereferencing(expectedDidDereferencing, receivedDidDereferencing)
+	utils.AssertResourceDataWithMetadata(expectedResourceDereferencing, receivedResourceDereferencing)
 },
 
 	Entry(

--- a/tests/integration/rest/test_utils.go
+++ b/tests/integration/rest/test_utils.go
@@ -38,7 +38,7 @@ type ResourceDereferencingResult struct {
 	Context               string                      `json:"@context,omitempty"`
 	DereferencingMetadata types.DereferencingMetadata `json:"dereferencingMetadata"`
 	ContentStream         *any                        `json:"contentStream"`
-	Metadata              *types.DereferencedResource `json:"contentMetadata"`
+	Metadata              *types.DereferencedResource `json:"contentMetadata,omitempty"`
 }
 
 func AssertDidDereferencing(expected DereferencingResult, received DereferencingResult) {
@@ -70,6 +70,15 @@ func AssertResourceDataWithMetadata(expected ResourceDereferencingResult, receiv
 	Expect(expected.Metadata.Version).To(Equal(received.Metadata.Version))
 	Expect(expected.Metadata.Name).To(Equal(received.Metadata.Name))
 	Expect(expected.Metadata.CollectionId).To(Equal(received.Metadata.CollectionId))
+}
+
+func AssertResourceMetadata(expected ResourceDereferencingResult, received ResourceDereferencingResult) {
+	Expect(expected.Context).To(Equal(received.Context))
+	Expect(expected.DereferencingMetadata.ContentType).To(Equal(received.DereferencingMetadata.ContentType))
+	Expect(expected.DereferencingMetadata.ResolutionError).To(Equal(received.DereferencingMetadata.ResolutionError))
+	Expect(expected.DereferencingMetadata.DidProperties).To(Equal(received.DereferencingMetadata.DidProperties))
+	Expect(expected.ContentStream).To(Equal(received.ContentStream))
+	Expect(expected.Metadata).To(Equal(received.Metadata))
 }
 
 func ConvertJsonFileToType(path string, v any) error {

--- a/tests/integration/rest/testdata/resource_metadata/metadata.json
+++ b/tests/integration/rest/testdata/resource_metadata/metadata.json
@@ -9,22 +9,18 @@
             "method": "cheqd"
         }
     },
-    "contentStream": {
-        "linkedResourceMetadata": [
-            {
-                "resourceURI": "did:cheqd:testnet:c1685ca0-1f5b-439c-8eb8-5c0e85ab7cd0/resources/9ba3922e-d5f5-4f53-b265-fc0d4e988c77",
-                "resourceCollectionId": "c1685ca0-1f5b-439c-8eb8-5c0e85ab7cd0",
-                "resourceId": "9ba3922e-d5f5-4f53-b265-fc0d4e988c77",
-                "resourceName": "Demo Resource",
-                "resourceType": "String",
-                "resourceVersion" : "",
-                "mediaType": "application/json",
-                "created": "2023-01-25T12:08:39Z",
-                "checksum": "e1dbc03b50bdb995961dc8843df6539b79d03bf49787ed6462189ee97d27eaf3",
-                "previousVersionId": null,
-                "nextVersionId": null
-            }
-        ]
-    },
-    "contentMetadata": {}
+    "contentStream": null,
+    "contentMetadata": {
+        "resourceURI": "did:cheqd:testnet:c1685ca0-1f5b-439c-8eb8-5c0e85ab7cd0/resources/9ba3922e-d5f5-4f53-b265-fc0d4e988c77",
+        "resourceCollectionId": "c1685ca0-1f5b-439c-8eb8-5c0e85ab7cd0",
+        "resourceId": "9ba3922e-d5f5-4f53-b265-fc0d4e988c77",
+        "resourceName": "Demo Resource",
+        "resourceType": "String",
+        "resourceVersion" : "",
+        "mediaType": "application/json",
+        "created": "2023-01-25T12:08:39Z",
+        "checksum": "e1dbc03b50bdb995961dc8843df6539b79d03bf49787ed6462189ee97d27eaf3",
+        "previousVersionId": null,
+        "nextVersionId": null
+    }
 }

--- a/tests/integration/rest/testdata/resource_metadata/metadata_32_indy_did.json
+++ b/tests/integration/rest/testdata/resource_metadata/metadata_32_indy_did.json
@@ -9,22 +9,18 @@
             "method": "cheqd"
         }
     },
-    "contentStream": {
-        "linkedResourceMetadata": [
-            {
-                "resourceURI": "did:cheqd:testnet:3KpiDD6Hxs4i2G7FtpiGhu/resources/214b8b61-a861-416b-a7e4-45533af40ada",
-                "resourceCollectionId": "3KpiDD6Hxs4i2G7FtpiGhu",
-                "resourceId": "214b8b61-a861-416b-a7e4-45533af40ada",
-                "resourceName": "RevRegEntry301071f2-314d-49e4-8e65-393586e5e05a",
-                "resourceType": "CL-RevRegEntry",
-                "resourceVersion" : "",
-                "mediaType": "application/json",
-                "created": "2022-10-12T09:00:02Z",
-                "checksum": "4bf7d5855a05955f84195f01ef7e8d91353a8895dc5d9022aebbcecc9f2c3dc6",
-                "previousVersionId": "616be02a-0838-42ee-b906-065fff3799ea",
-                "nextVersionId": "9f5b2985-990d-4160-94ed-06706043af7e"
-            }
-        ]
-    },
-    "contentMetadata": {}
+    "contentStream": null,
+    "contentMetadata": {
+        "resourceURI": "did:cheqd:testnet:3KpiDD6Hxs4i2G7FtpiGhu/resources/214b8b61-a861-416b-a7e4-45533af40ada",
+        "resourceCollectionId": "3KpiDD6Hxs4i2G7FtpiGhu",
+        "resourceId": "214b8b61-a861-416b-a7e4-45533af40ada",
+        "resourceName": "RevRegEntry301071f2-314d-49e4-8e65-393586e5e05a",
+        "resourceType": "CL-RevRegEntry",
+        "resourceVersion" : "",
+        "mediaType": "application/json",
+        "created": "2022-10-12T09:00:02Z",
+        "checksum": "4bf7d5855a05955f84195f01ef7e8d91353a8895dc5d9022aebbcecc9f2c3dc6",
+        "previousVersionId": "616be02a-0838-42ee-b906-065fff3799ea",
+        "nextVersionId": "9f5b2985-990d-4160-94ed-06706043af7e"
+    }
 }

--- a/tests/integration/rest/testdata/resource_metadata/metadata_did_json.json
+++ b/tests/integration/rest/testdata/resource_metadata/metadata_did_json.json
@@ -8,22 +8,18 @@
             "method": "cheqd"
         }
     },
-    "contentStream": {
-        "linkedResourceMetadata": [
-            {
-                "resourceURI": "did:cheqd:testnet:c1685ca0-1f5b-439c-8eb8-5c0e85ab7cd0/resources/9ba3922e-d5f5-4f53-b265-fc0d4e988c77",
-                "resourceCollectionId": "c1685ca0-1f5b-439c-8eb8-5c0e85ab7cd0",
-                "resourceId": "9ba3922e-d5f5-4f53-b265-fc0d4e988c77",
-                "resourceName": "Demo Resource",
-                "resourceType": "String",
-                "resourceVersion" : "",
-                "mediaType": "application/json",
-                "created": "2023-01-25T12:08:39Z",
-                "checksum": "e1dbc03b50bdb995961dc8843df6539b79d03bf49787ed6462189ee97d27eaf3",
-                "previousVersionId": null,
-                "nextVersionId": null
-            }
-        ]
-    },
-    "contentMetadata": {}
+    "contentStream": null,
+    "contentMetadata": {
+        "resourceURI": "did:cheqd:testnet:c1685ca0-1f5b-439c-8eb8-5c0e85ab7cd0/resources/9ba3922e-d5f5-4f53-b265-fc0d4e988c77",
+        "resourceCollectionId": "c1685ca0-1f5b-439c-8eb8-5c0e85ab7cd0",
+        "resourceId": "9ba3922e-d5f5-4f53-b265-fc0d4e988c77",
+        "resourceName": "Demo Resource",
+        "resourceType": "String",
+        "resourceVersion" : "",
+        "mediaType": "application/json",
+        "created": "2023-01-25T12:08:39Z",
+        "checksum": "e1dbc03b50bdb995961dc8843df6539b79d03bf49787ed6462189ee97d27eaf3",
+        "previousVersionId": null,
+        "nextVersionId": null
+    }
 }

--- a/tests/unit/resource/common/resource_dereference_metadata_service_test.go
+++ b/tests/unit/resource/common/resource_dereference_metadata_service_test.go
@@ -35,7 +35,6 @@ var _ = DescribeTable("Test DereferenceResourceMetadata method", func(testCase d
 		Expect(testCase.expectedError.Code).To(Equal(err.Code))
 		Expect(testCase.expectedError.Message).To(Equal(err.Message))
 	} else {
-		Expect(testCase.expectedResourceDereferencing.ContentStream).To(Equal(dereferencingResult.ContentStream))
 		Expect(testCase.expectedResourceDereferencing.Metadata).To(Equal(dereferencingResult.Metadata))
 		Expect(expectedContentType).To(Equal(dereferencingResult.DereferencingMetadata.ContentType))
 		Expect(testCase.expectedResourceDereferencing.DereferencingMetadata.DidProperties).To(Equal(dereferencingResult.DereferencingMetadata.DidProperties))
@@ -57,8 +56,10 @@ var _ = DescribeTable("Test DereferenceResourceMetadata method", func(testCase d
 						Method:           testconstants.ValidMethod,
 					},
 				},
-				ContentStream: testconstants.ValidDereferencedResourceList,
-				Metadata:      nil,
+				Metadata: types.NewDereferencedResource(
+					testconstants.ExistentDid,
+					testconstants.ValidResource[0].Metadata,
+				),
 			},
 			expectedError: nil,
 		},
@@ -78,8 +79,10 @@ var _ = DescribeTable("Test DereferenceResourceMetadata method", func(testCase d
 						Method:           testconstants.ValidMethod,
 					},
 				},
-				ContentStream: testconstants.ValidDereferencedResourceList,
-				Metadata:      nil,
+				Metadata: types.NewDereferencedResource(
+					testconstants.ExistentDid,
+					testconstants.ValidResource[0].Metadata,
+				),
 			},
 			expectedError: nil,
 		},
@@ -99,8 +102,10 @@ var _ = DescribeTable("Test DereferenceResourceMetadata method", func(testCase d
 						Method:           testconstants.ValidMethod,
 					},
 				},
-				ContentStream: testconstants.ValidDereferencedResourceList,
-				Metadata:      nil,
+				Metadata: types.NewDereferencedResource(
+					testconstants.ExistentDid,
+					testconstants.ValidResource[0].Metadata,
+				),
 			},
 			expectedError: types.NewNotFoundError(testconstants.NotExistentTestnetDid, types.DIDJSONLD, nil, true),
 		},

--- a/tests/unit/resource/request/request_service_dereference_resource_metadata_test.go
+++ b/tests/unit/resource/request/request_service_dereference_resource_metadata_test.go
@@ -12,7 +12,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	resourceTypes "github.com/cheqd/cheqd-node/api/v2/cheqd/resource/v2"
 	resourceServices "github.com/cheqd/did-resolver/services/resource"
 	testconstants "github.com/cheqd/did-resolver/tests/constants"
 	utils "github.com/cheqd/did-resolver/tests/unit"
@@ -28,7 +27,7 @@ type DereferencingResult struct {
 type resourceMetadataTestCase struct {
 	didURL                      string
 	resolutionType              types.ContentType
-	expectedDereferencingResult *DereferencingResult
+	expectedDereferencingResult *types.ResourceDereferencing
 	expectedError               error
 }
 
@@ -36,9 +35,7 @@ var _ = DescribeTable("Test ResourceMetadataEchoHandler function", func(testCase
 	request := httptest.NewRequest(http.MethodGet, testCase.didURL, nil)
 	context, rec := utils.SetupEmptyContext(request, testCase.resolutionType, utils.MockLedger)
 
-	if (testCase.resolutionType == "" || testCase.resolutionType == types.DIDJSONLD) && testCase.expectedError == nil {
-		testCase.expectedDereferencingResult.ContentStream.AddContext(types.DIDSchemaJSONLD)
-	} else if testCase.expectedDereferencingResult.ContentStream != nil {
+	if testCase.expectedDereferencingResult.ContentStream != nil {
 		testCase.expectedDereferencingResult.ContentStream.RemoveContext()
 	}
 	expectedContentType := utils.DefineContentType(testCase.expectedDereferencingResult.DereferencingMetadata.ContentType, testCase.resolutionType)
@@ -48,10 +45,9 @@ var _ = DescribeTable("Test ResourceMetadataEchoHandler function", func(testCase
 	if testCase.expectedError != nil {
 		Expect(testCase.expectedError.Error()).To(Equal(err.Error()))
 	} else {
-		var dereferencingResult DereferencingResult
+		var dereferencingResult *types.ResourceDereferencing
 		Expect(err).To(BeNil())
 		Expect(json.Unmarshal(rec.Body.Bytes(), &dereferencingResult)).To(BeNil())
-		Expect(testCase.expectedDereferencingResult.ContentStream, dereferencingResult.ContentStream)
 		Expect(testCase.expectedDereferencingResult.Metadata).To(Equal(dereferencingResult.Metadata))
 		Expect(expectedContentType).To(Equal(dereferencingResult.DereferencingMetadata.ContentType))
 		Expect(testCase.expectedDereferencingResult.DereferencingMetadata.DidProperties).To(Equal(dereferencingResult.DereferencingMetadata.DidProperties))
@@ -67,19 +63,18 @@ var _ = DescribeTable("Test ResourceMetadataEchoHandler function", func(testCase
 				testconstants.ExistentResourceId,
 			),
 			resolutionType: types.DIDJSONLD,
-			expectedDereferencingResult: &DereferencingResult{
-				DereferencingMetadata: &types.DereferencingMetadata{
+			expectedDereferencingResult: &types.ResourceDereferencing{
+				DereferencingMetadata: types.DereferencingMetadata{
 					DidProperties: types.DidProperties{
 						DidString:        testconstants.ExistentDid,
 						MethodSpecificId: testconstants.ValidIdentifier,
 						Method:           testconstants.ValidMethod,
 					},
 				},
-				ContentStream: types.NewDereferencedResourceListStruct(
+				Metadata: types.NewDereferencedResource(
 					testconstants.ExistentDid,
-					[]*resourceTypes.Metadata{testconstants.ValidResource[0].Metadata},
+					testconstants.ValidResource[0].Metadata,
 				),
-				Metadata: nil,
 			},
 			expectedError: nil,
 		},
@@ -94,8 +89,8 @@ var _ = DescribeTable("Test ResourceMetadataEchoHandler function", func(testCase
 				testconstants.ExistentResourceId,
 			),
 			resolutionType: types.DIDJSONLD,
-			expectedDereferencingResult: &DereferencingResult{
-				DereferencingMetadata: &types.DereferencingMetadata{
+			expectedDereferencingResult: &types.ResourceDereferencing{
+				DereferencingMetadata: types.DereferencingMetadata{
 					DidProperties: types.DidProperties{
 						DidString:        testconstants.NotExistentTestnetDid,
 						MethodSpecificId: testconstants.NotExistentIdentifier,
@@ -118,8 +113,8 @@ var _ = DescribeTable("Test ResourceMetadataEchoHandler function", func(testCase
 				testconstants.ExistentResourceId,
 			),
 			resolutionType: types.DIDJSONLD,
-			expectedDereferencingResult: &DereferencingResult{
-				DereferencingMetadata: &types.DereferencingMetadata{
+			expectedDereferencingResult: &types.ResourceDereferencing{
+				DereferencingMetadata: types.DereferencingMetadata{
 					DidProperties: types.DidProperties{
 						DidString:        testconstants.InvalidDid,
 						MethodSpecificId: testconstants.InvalidIdentifier,
@@ -142,8 +137,8 @@ var _ = DescribeTable("Test ResourceMetadataEchoHandler function", func(testCase
 				testconstants.NotExistentIdentifier,
 			),
 			resolutionType: types.DIDJSONLD,
-			expectedDereferencingResult: &DereferencingResult{
-				DereferencingMetadata: &types.DereferencingMetadata{
+			expectedDereferencingResult: &types.ResourceDereferencing{
+				DereferencingMetadata: types.DereferencingMetadata{
 					DidProperties: types.DidProperties{
 						DidString:        testconstants.ExistentDid,
 						MethodSpecificId: testconstants.ValidIdentifier,
@@ -166,8 +161,8 @@ var _ = DescribeTable("Test ResourceMetadataEchoHandler function", func(testCase
 				testconstants.InvalidIdentifier,
 			),
 			resolutionType: types.DIDJSONLD,
-			expectedDereferencingResult: &DereferencingResult{
-				DereferencingMetadata: &types.DereferencingMetadata{
+			expectedDereferencingResult: &types.ResourceDereferencing{
+				DereferencingMetadata: types.DereferencingMetadata{
 					DidProperties: types.DidProperties{
 						DidString:        testconstants.ExistentDid,
 						MethodSpecificId: testconstants.ValidIdentifier,
@@ -190,8 +185,8 @@ var _ = DescribeTable("Test ResourceMetadataEchoHandler function", func(testCase
 				testconstants.ExistentResourceId,
 			),
 			resolutionType: types.JSON,
-			expectedDereferencingResult: &DereferencingResult{
-				DereferencingMetadata: &types.DereferencingMetadata{
+			expectedDereferencingResult: &types.ResourceDereferencing{
+				DereferencingMetadata: types.DereferencingMetadata{
 					DidProperties: types.DidProperties{
 						DidString:        testconstants.ExistentDid,
 						MethodSpecificId: testconstants.ValidIdentifier,


### PR DESCRIPTION
This PR updates the response of 

- resources/<resource_id>/metadata

to return metadata in contentMetadata instead of contentStream