### PR TITLE
fix: respond with only diddoc [DEV-4787]

### DIFF
--- a/services/diddoc/diddoc_only.go
+++ b/services/diddoc/diddoc_only.go
@@ -27,7 +27,6 @@ func (dd *OnlyDIDDocRequestService) SpecificPrepare(c services.ResolverContext) 
 
 func (dd OnlyDIDDocRequestService) Respond(c services.ResolverContext) error {
 	_result := dd.Result.(*types.DidResolution)
-	_result.ResolutionMetadata = types.ResolutionMetadata{}
-	_result.Metadata = nil
-	return c.JSONPretty(http.StatusOK, _result, "  ")
+	// Return only the DidDocument
+	return c.JSONPretty(http.StatusOK, _result.Did, "  ")
 }

--- a/services/diddoc/diddoc_query.go
+++ b/services/diddoc/diddoc_query.go
@@ -366,5 +366,9 @@ func (dd QueryDIDDocRequestService) Respond(c services.ResolverContext) error {
 	}
 	// Get ContentType Formatted for response body
 	result := dd.FormatMetadataContentType(c)
+	if !dd.IsDereferencing && (dd.RequestedContentType == types.DIDJSON || dd.RequestedContentType == types.DIDJSONLD || dd.RequestedContentType == types.DIDRES) {
+		_result := result.(*types.DidResolution)
+		return c.JSONPretty(http.StatusOK, _result.Did, "  ")
+	}
 	return c.JSONPretty(http.StatusOK, result, "  ")
 }

--- a/services/request_service_base.go
+++ b/services/request_service_base.go
@@ -120,7 +120,7 @@ func (dd *BaseRequestService) Query(c ResolverContext) error {
 func (dd BaseRequestService) SetupResponse(c ResolverContext) error {
 	responseHeader := dd.Result.GetContentType()
 	if dd.Profile != "" && responseHeader == string(types.JSONLD) {
-		responseHeader = dd.Result.GetContentType() + ";profile=" + dd.Profile
+		responseHeader = dd.Result.GetContentType() + ";profile=\"" + dd.Profile + "\""
 	}
 	c.Response().Header().Set(echo.HeaderContentType, responseHeader)
 	if utils.IsGzipAccepted(c) {

--- a/tests/integration/rest/diddoc/diddoc/positive_test.go
+++ b/tests/integration/rest/diddoc/diddoc/positive_test.go
@@ -232,4 +232,18 @@ var _ = DescribeTable("Positive: Get DIDDoc", func(testCase utils.PositiveTestCa
 			ExpectedStatusCode: http.StatusOK,
 		},
 	),
+	Entry(
+		"can get DIDDoc with versionId query parameter and did+ld+json accept header",
+		utils.PositiveTestCase{
+			DidURL: fmt.Sprintf(
+				"http://%s/1.0/identifiers/%s?versionId=%s",
+				testconstants.TestHostAddress,
+				testconstants.SeveralVersionsDID,
+				"0ce23d04-5b67-4ea6-a315-788588e53f4e",
+			),
+			ResolutionType:     string(types.DIDJSONLD),
+			ExpectedJSONPath:   "../../testdata/diddoc/diddoc_version_did_ld.json",
+			ExpectedStatusCode: http.StatusOK,
+		},
+	),
 )

--- a/tests/integration/rest/diddoc/diddoc/positive_test.go
+++ b/tests/integration/rest/diddoc/diddoc/positive_test.go
@@ -24,16 +24,22 @@ var _ = DescribeTable("Positive: Get DIDDoc", func(testCase utils.PositiveTestCa
 		SetHeader("Accept-Encoding", testCase.EncodingType).
 		Get(testCase.DidURL)
 	Expect(err).To(BeNil())
+	Expect(testCase.ExpectedStatusCode).To(Equal(resp.StatusCode()))
+	Expect(testCase.ExpectedEncodingType).To(Equal(resp.Header().Get("Content-Encoding")))
 
 	var receivedDidResolution types.DidResolution
-	Expect(json.Unmarshal(resp.Body(), &receivedDidResolution)).To(BeNil())
-	Expect(testCase.ExpectedStatusCode).To(Equal(resp.StatusCode()))
-
-	var expectedDidResolution types.DidResolution
-	Expect(utils.ConvertJsonFileToType(testCase.ExpectedJSONPath, &expectedDidResolution)).To(BeNil())
-
-	Expect(testCase.ExpectedEncodingType).To(Equal(resp.Header().Get("Content-Encoding")))
-	utils.AssertDidResolution(expectedDidResolution, receivedDidResolution)
+	unmarshalErr := json.Unmarshal(resp.Body(), &receivedDidResolution)
+	if unmarshalErr != nil {
+		var resolutionResult types.DidDoc
+		var expectedResult types.DidDoc
+		Expect(utils.ConvertJsonFileToType(testCase.ExpectedJSONPath, &expectedResult)).To(BeNil())
+		Expect(json.Unmarshal(resp.Body(), &resolutionResult)).To(BeNil())
+		utils.AssertDidResolution(types.DidResolution{Did: &expectedResult}, types.DidResolution{Did: &resolutionResult})
+	} else {
+		var expectedDidResolution types.DidResolution
+		Expect(utils.ConvertJsonFileToType(testCase.ExpectedJSONPath, &expectedDidResolution)).To(BeNil())
+		utils.AssertDidResolution(expectedDidResolution, receivedDidResolution)
+	}
 },
 
 	Entry(

--- a/tests/integration/rest/testdata/diddoc/diddoc_did_json.json
+++ b/tests/integration/rest/testdata/diddoc/diddoc_did_json.json
@@ -1,49 +1,44 @@
 {
-    "didResolutionMetadata": {
-        "did": {}
-    },
-    "didDocument": {
-        "id": "did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN",
-        "verificationMethod": [
-            {
-                "id": "did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN#key1",
-                "type": "Ed25519VerificationKey2020",
-                "controller": "did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN",
-                "publicKeyMultibase": "z6Mkta7joRuvDh7UnoESdgpr9dDUMh5LvdoECDi3WGrJoscA"
-            }
-        ],
-        "authentication": [
-            "did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN#key1"
-        ],
-        "service": [
-            {
-                "id": "did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN#website",
-                "type": "LinkedDomains",
-                "serviceEndpoint": [
-                    "https://www.cheqd.io"
-                ]
-            },
-            {
-                "id": "did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN#non-fungible-image",
-                "type": "LinkedDomains",
-                "serviceEndpoint": [
-                    "https://gateway.ipfs.io/ipfs/bafybeihetj2ng3d74k7t754atv2s5dk76pcqtvxls6dntef3xa6rax25xe"
-                ]
-            },
-            {
-                "id": "did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN#twitter",
-                "type": "LinkedDomains",
-                "serviceEndpoint": [
-                    "https://twitter.com/cheqd_io"
-                ]
-            },
-            {
-                "id": "did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN#linkedin",
-                "type": "LinkedDomains",
-                "serviceEndpoint": [
-                    "https://www.linkedin.com/company/cheqd-identity/"
-                ]
-            }
-        ]
-    }
+    "id": "did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN",
+    "verificationMethod": [
+        {
+            "id": "did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN#key1",
+            "type": "Ed25519VerificationKey2020",
+            "controller": "did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN",
+            "publicKeyMultibase": "z6Mkta7joRuvDh7UnoESdgpr9dDUMh5LvdoECDi3WGrJoscA"
+        }
+    ],
+    "authentication": [
+        "did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN#key1"
+    ],
+    "service": [
+        {
+            "id": "did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN#website",
+            "type": "LinkedDomains",
+            "serviceEndpoint": [
+                "https://www.cheqd.io"
+            ]
+        },
+        {
+            "id": "did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN#non-fungible-image",
+            "type": "LinkedDomains",
+            "serviceEndpoint": [
+                "https://gateway.ipfs.io/ipfs/bafybeihetj2ng3d74k7t754atv2s5dk76pcqtvxls6dntef3xa6rax25xe"
+            ]
+        },
+        {
+            "id": "did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN#twitter",
+            "type": "LinkedDomains",
+            "serviceEndpoint": [
+                "https://twitter.com/cheqd_io"
+            ]
+        },
+        {
+            "id": "did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN#linkedin",
+            "type": "LinkedDomains",
+            "serviceEndpoint": [
+                "https://www.linkedin.com/company/cheqd-identity/"
+            ]
+        }
+    ]
 }

--- a/tests/integration/rest/testdata/diddoc/diddoc_indy_mainnet_did_ld.json
+++ b/tests/integration/rest/testdata/diddoc/diddoc_indy_mainnet_did_ld.json
@@ -1,47 +1,41 @@
 {
-  "@context": "https://w3id.org/did-resolution/v1",
-  "didResolutionMetadata": {
-    "did": {}
-  },
-  "didDocument": {
-    "@context": [
-      "https://www.w3.org/ns/did/v1",
-      "https://identity.foundation/.well-known/did-configuration/v1",
-      "https://w3id.org/security/suites/ed25519-2020/v1"
-    ],
-    "id": "did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN",
-    "verificationMethod": [
-      {
-        "id": "did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN#key1",
-        "type": "Ed25519VerificationKey2020",
-        "controller": "did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN",
-        "publicKeyMultibase": "z6Mkta7joRuvDh7UnoESdgpr9dDUMh5LvdoECDi3WGrJoscA"
-      }
-    ],
-    "authentication": ["did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN#key1"],
-    "service": [
-      {
-        "id": "did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN#website",
-        "type": "LinkedDomains",
-        "serviceEndpoint": ["https://www.cheqd.io"]
-      },
-      {
-        "id": "did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN#non-fungible-image",
-        "type": "LinkedDomains",
-        "serviceEndpoint": [
-          "https://gateway.ipfs.io/ipfs/bafybeihetj2ng3d74k7t754atv2s5dk76pcqtvxls6dntef3xa6rax25xe"
-        ]
-      },
-      {
-        "id": "did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN#twitter",
-        "type": "LinkedDomains",
-        "serviceEndpoint": ["https://twitter.com/cheqd_io"]
-      },
-      {
-        "id": "did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN#linkedin",
-        "type": "LinkedDomains",
-        "serviceEndpoint": ["https://www.linkedin.com/company/cheqd-identity/"]
-      }
-    ]
-  }
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://identity.foundation/.well-known/did-configuration/v1",
+    "https://w3id.org/security/suites/ed25519-2020/v1"
+  ],
+  "id": "did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN",
+  "verificationMethod": [
+    {
+      "id": "did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN#key1",
+      "type": "Ed25519VerificationKey2020",
+      "controller": "did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN",
+      "publicKeyMultibase": "z6Mkta7joRuvDh7UnoESdgpr9dDUMh5LvdoECDi3WGrJoscA"
+    }
+  ],
+  "authentication": ["did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN#key1"],
+  "service": [
+    {
+      "id": "did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN#website",
+      "type": "LinkedDomains",
+      "serviceEndpoint": ["https://www.cheqd.io"]
+    },
+    {
+      "id": "did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN#non-fungible-image",
+      "type": "LinkedDomains",
+      "serviceEndpoint": [
+        "https://gateway.ipfs.io/ipfs/bafybeihetj2ng3d74k7t754atv2s5dk76pcqtvxls6dntef3xa6rax25xe"
+      ]
+    },
+    {
+      "id": "did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN#twitter",
+      "type": "LinkedDomains",
+      "serviceEndpoint": ["https://twitter.com/cheqd_io"]
+    },
+    {
+      "id": "did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN#linkedin",
+      "type": "LinkedDomains",
+      "serviceEndpoint": ["https://www.linkedin.com/company/cheqd-identity/"]
+    }
+  ]
 }

--- a/tests/integration/rest/testdata/diddoc/diddoc_version_did_ld.json
+++ b/tests/integration/rest/testdata/diddoc/diddoc_version_did_ld.json
@@ -1,0 +1,18 @@
+{
+    "@context": [
+        "https://www.w3.org/ns/did/v1",
+        "https://w3id.org/security/suites/ed25519-2018/v1"
+    ],
+    "id": "did:cheqd:testnet:b5d70adf-31ca-4662-aa10-d3a54cd8f06c",
+    "verificationMethod": [
+        {
+            "id": "did:cheqd:testnet:b5d70adf-31ca-4662-aa10-d3a54cd8f06c#key-1",
+            "type": "Ed25519VerificationKey2018",
+            "controller": "did:cheqd:testnet:b5d70adf-31ca-4662-aa10-d3a54cd8f06c",
+            "publicKeyBase58": "BpVGbTeT26LipAdk26DBZrmJx2939i9gZS5VxGt1zZQ6"
+        }
+    ],
+    "authentication": [
+        "did:cheqd:testnet:b5d70adf-31ca-4662-aa10-d3a54cd8f06c#key-1"
+    ]
+}

--- a/tests/unit/diddoc/request/diddoc_positive_cases_test.go
+++ b/tests/unit/diddoc/request/diddoc_positive_cases_test.go
@@ -50,7 +50,7 @@ var _ = DescribeTable("Test Query handlers with versionId and versionTime params
 		"Positive. VersionId case. The first item",
 		QueriesDIDDocTestCase{
 			didURL:         fmt.Sprintf("/1.0/identifiers/%s?versionId=%s", testconstants.ValidDid, VersionId1),
-			resolutionType: types.DIDJSONLD,
+			resolutionType: types.JSON,
 			expectedResolution: &types.DidResolution{
 				ResolutionMetadata: types.ResolutionMetadata{
 					DidProperties: types.DidProperties{
@@ -72,7 +72,7 @@ var _ = DescribeTable("Test Query handlers with versionId and versionTime params
 		"Positive. VersionId case. The second item. All the resources should be returned",
 		QueriesDIDDocTestCase{
 			didURL:         fmt.Sprintf("/1.0/identifiers/%s?versionId=%s", testconstants.ValidDid, VersionId2),
-			resolutionType: types.DIDJSONLD,
+			resolutionType: types.JSON,
 			expectedResolution: &types.DidResolution{
 				ResolutionMetadata: types.ResolutionMetadata{
 					DidProperties: types.DidProperties{
@@ -103,7 +103,7 @@ var _ = DescribeTable("Test Query handlers with versionId and versionTime params
 		"Positive. VersionTime case. Case after creation but before update",
 		QueriesDIDDocTestCase{
 			didURL:         fmt.Sprintf("/1.0/identifiers/%s?versionTime=%s", testconstants.ValidDid, DidDocAfterCreated.Format(time.RFC3339Nano)),
-			resolutionType: types.DIDJSONLD,
+			resolutionType: types.JSON,
 			expectedResolution: &types.DidResolution{
 				ResolutionMetadata: types.ResolutionMetadata{
 					DidProperties: types.DidProperties{
@@ -125,7 +125,7 @@ var _ = DescribeTable("Test Query handlers with versionId and versionTime params
 		"Positive. VersionTime case. Case after updating",
 		QueriesDIDDocTestCase{
 			didURL:         fmt.Sprintf("/1.0/identifiers/%s?versionTime=%s", testconstants.ValidDid, DidDocAfterUpdated.Format(time.RFC3339Nano)),
-			resolutionType: types.DIDJSONLD,
+			resolutionType: types.JSON,
 			expectedResolution: &types.DidResolution{
 				ResolutionMetadata: types.ResolutionMetadata{
 					DidProperties: types.DidProperties{
@@ -156,7 +156,7 @@ var _ = DescribeTable("Test Query handlers with versionId and versionTime params
 		"Positive. VersionTime and VersionId case. Case after creation but before update",
 		QueriesDIDDocTestCase{
 			didURL:         fmt.Sprintf("/1.0/identifiers/%s?versionTime=%s&versionId=%s", testconstants.ValidDid, DidDocAfterCreated.Format(time.RFC3339Nano), VersionId1),
-			resolutionType: types.DIDJSONLD,
+			resolutionType: types.JSON,
 			expectedResolution: &types.DidResolution{
 				ResolutionMetadata: types.ResolutionMetadata{
 					DidProperties: types.DidProperties{
@@ -178,7 +178,7 @@ var _ = DescribeTable("Test Query handlers with versionId and versionTime params
 		"Positive. Metadata = false. Should omit the metadata section",
 		QueriesDIDDocTestCase{
 			didURL:         fmt.Sprintf("/1.0/identifiers/%s?metadata=false", testconstants.ValidDid),
-			resolutionType: types.DIDJSONLD,
+			resolutionType: types.JSON,
 			expectedResolution: &types.DidResolution{
 				ResolutionMetadata: types.ResolutionMetadata{
 					DidProperties: types.DidProperties{

--- a/tests/unit/diddoc/request/diddoc_resolution_query_positive_test.go
+++ b/tests/unit/diddoc/request/diddoc_resolution_query_positive_test.go
@@ -79,7 +79,7 @@ var _ = DescribeTable("Tests for mixed DidDoc and resource cases", func(testCase
 				DidDocUpdated.Format(time.RFC3339Nano),
 				ResourceIdName1,
 			),
-			acceptHeader:   string(types.JSONLD) + ";profile=" + types.W3IDDIDRES,
+			acceptHeader:   string(types.JSONLD) + ";profile=\"" + types.W3IDDIDRES + "\"",
 			resolutionType: types.JSONLD,
 			expectedDIDResolution: &types.DidResolution{
 				ResolutionMetadata: types.ResolutionMetadata{
@@ -111,7 +111,7 @@ var _ = DescribeTable("Tests for mixed DidDoc and resource cases", func(testCase
 				ResourceIdName1,
 				ResourceName1.Metadata.CollectionId,
 			),
-			acceptHeader:   string(types.JSONLD) + ";profile=" + types.W3IDDIDRES,
+			acceptHeader:   string(types.JSONLD) + ";profile=\"" + types.W3IDDIDRES + "\"",
 			resolutionType: types.JSONLD,
 			expectedDIDResolution: &types.DidResolution{
 				ResolutionMetadata: types.ResolutionMetadata{
@@ -142,7 +142,7 @@ var _ = DescribeTable("Tests for mixed DidDoc and resource cases", func(testCase
 				DidDocUpdated.Format(time.RFC3339Nano),
 				ResourceName1.Metadata.CollectionId,
 			),
-			acceptHeader:   string(types.JSONLD) + ";profile=" + types.W3IDDIDRES,
+			acceptHeader:   string(types.JSONLD) + ";profile=\"" + types.W3IDDIDRES + "\"",
 			resolutionType: types.JSONLD,
 			expectedDIDResolution: &types.DidResolution{
 				ResolutionMetadata: types.ResolutionMetadata{
@@ -179,7 +179,7 @@ var _ = DescribeTable("Tests for mixed DidDoc and resource cases", func(testCase
 				ResourceName1.Metadata.CollectionId,
 				ResourceName1.Metadata.Name,
 			),
-			acceptHeader:   string(types.JSONLD) + ";profile=" + types.W3IDDIDRES,
+			acceptHeader:   string(types.JSONLD) + ";profile=\"" + types.W3IDDIDRES + "\"",
 			resolutionType: types.JSONLD,
 			expectedDIDResolution: &types.DidResolution{
 				ResolutionMetadata: types.ResolutionMetadata{
@@ -213,7 +213,7 @@ var _ = DescribeTable("Tests for mixed DidDoc and resource cases", func(testCase
 				ResourceName1.Metadata.Name,
 				ResourceName1.Metadata.ResourceType,
 			),
-			acceptHeader:   string(types.JSONLD) + ";profile=" + types.W3IDDIDRES,
+			acceptHeader:   string(types.JSONLD) + ";profile=\"" + types.W3IDDIDRES + "\"",
 			resolutionType: types.JSONLD,
 			expectedDIDResolution: &types.DidResolution{
 				ResolutionMetadata: types.ResolutionMetadata{
@@ -248,7 +248,7 @@ var _ = DescribeTable("Tests for mixed DidDoc and resource cases", func(testCase
 				ResourceName1.Metadata.ResourceType,
 				ResourceName1.Metadata.Version,
 			),
-			acceptHeader:   string(types.JSONLD) + ";profile=" + types.W3IDDIDRES,
+			acceptHeader:   string(types.JSONLD) + ";profile=\"" + types.W3IDDIDRES + "\"",
 			resolutionType: types.JSONLD,
 			expectedDIDResolution: &types.DidResolution{
 				ResolutionMetadata: types.ResolutionMetadata{
@@ -284,7 +284,7 @@ var _ = DescribeTable("Tests for mixed DidDoc and resource cases", func(testCase
 				ResourceName1.Metadata.Version,
 				DidDocUpdated.Format(time.RFC3339),
 			),
-			acceptHeader:   string(types.JSONLD) + ";profile=" + types.W3IDDIDRES,
+			acceptHeader:   string(types.JSONLD) + ";profile=\"" + types.W3IDDIDRES + "\"",
 			resolutionType: types.JSONLD,
 			expectedDIDResolution: &types.DidResolution{
 				ResolutionMetadata: types.ResolutionMetadata{
@@ -321,7 +321,7 @@ var _ = DescribeTable("Tests for mixed DidDoc and resource cases", func(testCase
 				DidDocUpdated.Format(time.RFC3339),
 				ResourceName1.Metadata.Checksum,
 			),
-			acceptHeader:   string(types.JSONLD) + ";profile=" + types.W3IDDIDRES,
+			acceptHeader:   string(types.JSONLD) + ";profile=\"" + types.W3IDDIDRES + "\"",
 			resolutionType: types.JSONLD,
 			expectedDIDResolution: &types.DidResolution{
 				ResolutionMetadata: types.ResolutionMetadata{
@@ -352,7 +352,7 @@ var _ = DescribeTable("Tests for mixed DidDoc and resource cases", func(testCase
 				DidDocUpdated.Format(time.RFC3339Nano),
 				Resource2Created.Format(time.RFC3339),
 			),
-			acceptHeader:   string(types.JSONLD) + ";profile=" + types.W3IDDIDRES,
+			acceptHeader:   string(types.JSONLD) + ";profile=\"" + types.W3IDDIDRES + "\"",
 			resolutionType: types.JSONLD,
 			expectedDIDResolution: &types.DidResolution{
 				ResolutionMetadata: types.ResolutionMetadata{

--- a/tests/unit/diddoc/request/diddoc_transform_key_test.go
+++ b/tests/unit/diddoc/request/diddoc_transform_key_test.go
@@ -54,7 +54,7 @@ var _ = DescribeTable("Test Query handler with transformKeys params", func(testC
 				testconstants.ValidDid,
 				types.Ed25519VerificationKey2018,
 			),
-			resolutionType: types.DIDJSONLD,
+			resolutionType: types.JSON,
 			expectedResolution: &types.DidResolution{
 				ResolutionMetadata: types.ResolutionMetadata{
 					DidProperties: types.DidProperties{
@@ -91,7 +91,7 @@ var _ = DescribeTable("Test Query handler with transformKeys params", func(testC
 				testconstants.ValidDid,
 				types.Ed25519VerificationKey2020,
 			),
-			resolutionType: types.DIDJSONLD,
+			resolutionType: types.JSON,
 			expectedResolution: &types.DidResolution{
 				ResolutionMetadata: types.ResolutionMetadata{
 					DidProperties: types.DidProperties{

--- a/tests/unit/diddoc/request/request_service_resolve_did_doc_test.go
+++ b/tests/unit/diddoc/request/request_service_resolve_did_doc_test.go
@@ -86,7 +86,7 @@ var _ = DescribeTable("Test DIDDocEchoHandler function", func(testCase resolveDI
 		resolveDIDDocTestCase{
 			didURL:         fmt.Sprintf("/1.0/identifiers/%s", testconstants.ExistentDid),
 			resolutionType: types.JSONLD,
-			acceptHeader:   string(types.JSONLD) + ";profile=" + types.W3IDDIDRES,
+			acceptHeader:   string(types.JSONLD) + ";profile=\"" + types.W3IDDIDRES + "\"",
 			expectedDIDResolution: &types.DidResolution{
 				ResolutionMetadata: types.ResolutionMetadata{
 					ContentType: types.DIDRES,

--- a/tests/unit/diddoc/request/request_service_resolve_did_doc_test.go
+++ b/tests/unit/diddoc/request/request_service_resolve_did_doc_test.go
@@ -23,7 +23,7 @@ type resolveDIDDocTestCase struct {
 	didURL                string
 	resolutionType        types.ContentType
 	acceptHeader          string
-	expectedDIDResolution *types.DidResolution
+	expectedDIDResolution interface{} // interface to accept type DidResolution as well as DidDocument
 	expectedError         error
 }
 
@@ -32,30 +32,55 @@ var _ = DescribeTable("Test DIDDocEchoHandler function", func(testCase resolveDI
 	request.Header.Set("Accept", testCase.acceptHeader) // Set Accept header dynamically
 	context, rec := utils.SetupEmptyContext(request, testCase.resolutionType, utils.MockLedger)
 
-	if (testCase.resolutionType == "" || testCase.resolutionType == types.JSONLD) && testCase.expectedError == nil {
-		testCase.expectedDIDResolution.Did.Context = []string{types.DIDSchemaJSONLD, types.LinkedDomainsJSONLD, types.JsonWebKey2020JSONLD}
-	} else if testCase.expectedDIDResolution.Did != nil {
-		testCase.expectedDIDResolution.Did.Context = nil
+	var didDoc *types.DidDoc
+	var didResolution *types.DidResolution
+
+	switch v := testCase.expectedDIDResolution.(type) {
+	case *types.DidDoc:
+		didDoc = v
+	case *types.DidResolution:
+		didResolution = v
+	}
+	if didResolution != nil {
+		if (testCase.resolutionType == "" || testCase.resolutionType == types.JSONLD) && testCase.expectedError == nil {
+			didResolution.Did.Context = []string{types.DIDSchemaJSONLD, types.LinkedDomainsJSONLD, types.JsonWebKey2020JSONLD}
+		}
+	} else if didDoc != nil {
+		didDoc.Context = nil
 	}
 
-	expectedContentType := utils.DefineContentType(testCase.expectedDIDResolution.ResolutionMetadata.ContentType, testCase.resolutionType)
+	expectedContentType := utils.DefineContentType(
+		func() types.ContentType {
+			if didResolution != nil {
+				return didResolution.ResolutionMetadata.ContentType
+			}
+			return ""
+		}(),
+		testCase.resolutionType,
+	)
 	responseContentType := utils.ResponseContentType(testCase.acceptHeader, false)
 
 	err := didDocServices.DidDocEchoHandler(context)
 	if testCase.expectedError != nil {
 		Expect(testCase.expectedError.Error()).To(Equal(err.Error()))
 	} else {
-		var resolutionResult types.DidResolution
 		Expect(err).To(BeNil())
-		Expect(json.Unmarshal(rec.Body.Bytes(), &resolutionResult)).To(BeNil())
-		Expect(testCase.expectedDIDResolution.Did).To(Equal(resolutionResult.Did))
-		Expect(testCase.expectedDIDResolution.Metadata).To(Equal(resolutionResult.Metadata))
-		Expect(expectedContentType).To(Equal(resolutionResult.ResolutionMetadata.ContentType))
-		Expect(testCase.expectedDIDResolution.ResolutionMetadata.DidProperties).To(Equal(resolutionResult.ResolutionMetadata.DidProperties))
-		Expect(responseContentType).To(Equal(rec.Header().Get("Content-Type")))
+		if didDoc != nil {
+			var resolutionResult types.DidDoc
+			Expect(json.Unmarshal(rec.Body.Bytes(), &resolutionResult)).To(BeNil())
+			Expect(didDoc).To(Equal(resolutionResult))
+			Expect(expectedContentType).To(Equal(rec.Header().Get("Content-Type")))
+		} else if didResolution != nil {
+			var resolutionResult types.DidResolution
+			Expect(json.Unmarshal(rec.Body.Bytes(), &resolutionResult)).To(BeNil())
+			Expect(didResolution.Did).To(Equal(resolutionResult.Did))
+			Expect(didResolution.Metadata).To(Equal(resolutionResult.Metadata))
+			Expect(expectedContentType).To(Equal(resolutionResult.ResolutionMetadata.ContentType))
+			Expect(didResolution.ResolutionMetadata.DidProperties).To(Equal(resolutionResult.ResolutionMetadata.DidProperties))
+			Expect(responseContentType).To(Equal(rec.Header().Get("Content-Type")))
+		}
 	}
 },
-
 	Entry(
 		"can get DIDDoc with an existent DID",
 		resolveDIDDocTestCase{
@@ -78,6 +103,36 @@ var _ = DescribeTable("Test DIDDocEchoHandler function", func(testCase resolveDI
 				),
 			},
 			expectedError: nil,
+		},
+	),
+	Entry(
+		"can get DIDDoc with an existent DID and application/did accept header",
+		resolveDIDDocTestCase{
+			didURL:                fmt.Sprintf("/1.0/identifiers/%s", testconstants.ExistentDid),
+			resolutionType:        types.DIDRES,
+			acceptHeader:          string(types.DIDRES),
+			expectedDIDResolution: testconstants.ValidDIDDocResolution,
+			expectedError:         nil,
+		},
+	),
+	Entry(
+		"can get DIDDoc with an existent DID and application/did+json accept header",
+		resolveDIDDocTestCase{
+			didURL:                fmt.Sprintf("/1.0/identifiers/%s", testconstants.ExistentDid),
+			resolutionType:        types.DIDJSON,
+			acceptHeader:          string(types.DIDJSON),
+			expectedDIDResolution: testconstants.ValidDIDDocResolution,
+			expectedError:         nil,
+		},
+	),
+	Entry(
+		"can get DIDDoc with an existent DID and application/did+ld+json accept header",
+		resolveDIDDocTestCase{
+			didURL:                fmt.Sprintf("/1.0/identifiers/%s", testconstants.ExistentDid),
+			resolutionType:        types.DIDJSONLD,
+			acceptHeader:          string(types.DIDJSONLD),
+			expectedDIDResolution: testconstants.ValidDIDDocResolution,
+			expectedError:         nil,
 		},
 	),
 
@@ -106,12 +161,7 @@ var _ = DescribeTable("Test DIDDocEchoHandler function", func(testCase resolveDI
 		resolveDIDDocTestCase{
 			didURL: fmt.Sprintf(
 				"/1.0/identifiers/%s",
-				fmt.Sprintf(
-					testconstants.DIDStructure,
-					testconstants.InvalidMethod,
-					testconstants.ValidTestnetNamespace,
-					testconstants.ValidIdentifier,
-				),
+				testconstants.TestnetDidWithInvalidMethod,
 			),
 			resolutionType: types.DIDJSONLD,
 			expectedDIDResolution: &types.DidResolution{

--- a/tests/unit/test_utils.go
+++ b/tests/unit/test_utils.go
@@ -29,7 +29,7 @@ func DefineContentType(expectedContentType types.ContentType, resolutionType typ
 func ResponseContentType(acceptHeader string, resource bool) string {
 	contentType, profile := services.GetPriorityContentType(acceptHeader, resource)
 	if profile != "" {
-		return string(contentType) + ";profile=" + profile
+		return string(contentType) + ";profile=\"" + profile + "\""
 	}
 	return string(contentType)
 }


### PR DESCRIPTION
- Response only contains DidDoc for `application/did` or `application/did+json`  or `application/did+ld+json` Accept headers
- Updated Integration Testcases
- Updated Unit test suite to handle both DID Doc and DID Resolution