### PR TITLE
ci: Multi-Architecture Docker Builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+.github

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      
+
       - uses: actions/setup-go@v5
         with:
           go-version-file: ./go.mod
@@ -44,11 +44,10 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        id: buildx
         with:
           install: true
           version: latest
-      
+
       - name: Configure Docker image metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -61,7 +60,7 @@ jobs:
             type=ref,event=branch
             type=raw,value=staging-latest
             type=sha,format=long
-      
+
       - name: Build image
         uses: docker/build-push-action@v6
         with:
@@ -71,9 +70,9 @@ jobs:
           load: true
           tags: ${{ steps.meta.outputs.tags }}
           outputs: type=docker,dest=did-resolver-staging.tar
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
-      
+          cache-from: type=gha,scope=docker-build-amd64
+          cache-to: type=gha,scope=docker-build-amd64,mode=max
+
       - name: Upload staging image as an artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,11 +7,11 @@ defaults:
 
 
 jobs:
-  
+
   md-link-check:
     name: "Broken Markdown links"
     runs-on: ubuntu-latest
-    
+
     steps:
       - uses: actions/checkout@v4
 
@@ -20,13 +20,13 @@ jobs:
         with:
           config-file: '.github/linters/mlc_config.json'
           use-quiet-mode: 'yes'
-  
+
   go-lint:
     # We can't use VALIDATE_GO from super linter because of this issue:
     # https://github.com/github/super-linter/issues/143
     name: "Golang Lint"
     runs-on: ubuntu-latest
-    
+
     steps:
       - uses: actions/checkout@v4
 
@@ -46,14 +46,14 @@ jobs:
   super-lint:
     name: "Super Linter"
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0 # Required to fetch version
-    
+
     - name: Run Super Linter
-      uses: github/super-linter/slim@v7
+      uses: super-linter/super-linter/slim@v7
       env:
         IGNORE_GITIGNORED_FILES: true
         DEFAULT_BRANCH: main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,7 +201,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
+          push: false # Todo: Test setting to `true` to replace `docker image push`
           file: docker/Dockerfile
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
@@ -209,3 +209,9 @@ jobs:
           cache-from: |
             type=gha,scope=docker-release-amd64
             type=gha,scope=docker-release-arm64
+
+      - name: Push image to GitHub Container Registry
+        run: docker image push --all-tags ghcr.io/${{ github.repository}}
+
+      - name: Push image to DigitalOcean Container Registry
+        run: docker image push --all-tags registry.digitalocean.com/${{ github.repository }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,9 +94,53 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  release-docker:
-    name: "Release Docker image"
+  build-docker:
+    name: Build Docker image
     needs: release-guard
+    runs-on: ${{ matrix.runs-on }}
+    if: ${{ github.ref_name == 'main' }}
+    env:
+      IMAGE_NAME: ${{ github.repository }}
+    environment:
+      name: production
+      url: https://resolver.cheqd.net
+
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+        include:
+          - arch: amd64
+            runs-on: ubuntu-24.04
+          - arch: arm64
+            runs-on: ubuntu-24.04-arm
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        id: buildx
+        with:
+          install: true
+          version: latest
+
+      - name: Build and cache image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          file: docker/Dockerfile
+          platforms: linux/${{ matrix.arch }}
+          cache-from: type=gha,scope=docker-release-${{ matrix.arch }}
+          cache-to: type=gha,scope=docker-release-${{ matrix.arch }},mode=max
+
+  release-docker:
+    name: Release Docker image
+    needs:
+      - release-guard
+      - build-docker
     runs-on: ubuntu-latest
     if: ${{ github.ref_name == 'main' }}
     env:
@@ -153,20 +197,15 @@ jobs:
             org.opencontainers.image.created={{date 'dddd, MMMM Do YYYY, h:mm:ss a'}}
             org.opencontainers.image.documentation="https://docs.cheqd.io/identity"
 
-      - name: Build image with labels
+      - name: Build and push image
         uses: docker/build-push-action@v6
         with:
           context: .
+          push: true
           file: docker/Dockerfile
-          platforms: linux/amd64
-          load: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
-
-      - name: Push image to GitHub Container Registry
-        run: docker image push --all-tags ghcr.io/${{ github.repository}}
-
-      - name: Push image to DigitalOcean Container Registry
-        run: docker image push --all-tags registry.digitalocean.com/${{ github.repository }}
+          cache-from: |
+            type=gha,scope=docker-release-amd64
+            type=gha,scope=docker-release-arm64

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -6,16 +6,16 @@ defaults:
     shell: bash
 
 jobs:
-  
+
   deploy-staging:
     name: "Staging Deploy"
     runs-on: ubuntu-latest
-    env: 
+    env:
       IMAGE_NAME: ${{ github.repository }}
-    environment: 
+    environment:
       name: staging
       url: https://resolver-staging.cheqd.net
-    
+
     steps:
       - name: Install DigitalOcean CLI
         uses: digitalocean/action-doctl@v2
@@ -40,9 +40,9 @@ jobs:
     name: "Release Staging Docker image"
     runs-on: ubuntu-latest
     if: ${{ github.ref_name == 'develop' }}
-    env: 
+    env:
       IMAGE_NAME: ${{ github.repository }}
-    
+
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/tests/docker-compose-testing.yml
+++ b/tests/docker-compose-testing.yml
@@ -14,7 +14,7 @@ services:
     #   dockerfile: docker/Dockerfile
     #   target: resolver
     # CAUTION: Change IMAGE_VERSION to local in docker-compose.env if building your own image in section below
-    image: cheqd/did-resolver:staging-latest
+    image: ${IMAGE_NAME:-cheqd/did-resolver}:staging-latest
     ports:
       - target: 8080
         published: 8080


### PR DESCRIPTION
This PR adds support for building Docker images for both `amd64` and
`arm64` architectures.

Changes:
- Implement matrix strategy in `release.yml` to build for both `amd64`
and `arm64`
- Split Docker build and publish steps into separate jobs for better
control and parallelization
- Update caching strategy to be architecture-specific, improving build
performance
- ~Simplify Docker push by using built-in push parameter instead of
separate docker push commands~ -  Reverted this, will do a follow-up PR for independent review/testing
- Use dedicated runners (`ubuntu-24.04` and `ubuntu-24.04-arm`) optimized
for each architecture
- Update Super Linter
  - `github/super-linter` is outdated
  - Doesn't know about `ubuntu-24.04-arm`
- Add `.dockerignore`
  - Currently ignores `.git` and `.github`
  - Prevents changes to git from invalidating entire Docker cache