### PR TITLE
ci: Fix pushing released images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,7 +201,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          load: true
+          push: true
           file: docker/Dockerfile
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
@@ -209,9 +209,3 @@ jobs:
           cache-from: |
             type=gha,scope=docker-release-amd64
             type=gha,scope=docker-release-arm64
-
-      - name: Push image to GitHub Container Registry
-        run: docker image push --all-tags ghcr.io/${{ github.repository}}
-
-      - name: Push image to DigitalOcean Container Registry
-        run: docker image push --all-tags registry.digitalocean.com/${{ github.repository }}


### PR DESCRIPTION
Set `push: true` in Build and push image step.

This makes the following `docker push` commands
unnecessary, so have removed them.