### PR TITLE
ci: Bump CI-related packages on did-resolver repository [DEV-5612]

### DIFF
--- a/.github/linters/.golangci.yaml
+++ b/.github/linters/.golangci.yaml
@@ -1,3 +1,5 @@
+version: 2
+
 run:
   timeout: 10m
 

--- a/.github/linters/.golangci.yaml
+++ b/.github/linters/.golangci.yaml
@@ -13,9 +13,7 @@ linters:
     - errcheck
     - goconst
     - gocritic
-    - gofumpt
-    - goimports
-    - gosimple
+    # - gosimple # Merged into staticcheck in v2
     - govet
     - ineffassign
     - misspell
@@ -23,10 +21,15 @@ linters:
     - nestif
     - nolintlint
     - staticcheck
-    # - stylecheck # Disable stylecheck until refactor
+    # - stylecheck # Merged into staticcheck in v2
     # - typecheck # Removed in v2
     - unconvert
     - unused
+
+formatters:
+  enable:
+    - gofumpt
+    - goimports
 
 
 linters-settings:
@@ -42,9 +45,6 @@ linters-settings:
     disabled-checks:
       - regexpMust
       - badCall # Remove this after CI workflow PR
-
-  gofumpt:
-    lang-version: "1.24"
     
   misspell:
     ignore-words:
@@ -52,7 +52,7 @@ linters-settings:
       - cheq
       - ncheq
 
-  stylecheck:
+  staticcheck:
     # Select the Go version to target.
     go: "1.24"
     # STxxxx checks in https://staticcheck.io/docs/configuration/options/#checks

--- a/.github/linters/.golangci.yaml
+++ b/.github/linters/.golangci.yaml
@@ -1,5 +1,3 @@
-version: "2"
-
 run:
   timeout: 10m
 
@@ -8,12 +6,14 @@ linters:
   enable:
     - bodyclose
     - copyloopvar
-    # - depguard # Disabled - no import restrictions applied earlier
+    - depguard
     - dogsled
     - errcheck
     - goconst
     - gocritic
-    # - gosimple # Merged into staticcheck in v2
+    - gofumpt
+    - goimports
+    - gosimple
     - govet
     - ineffassign
     - misspell
@@ -21,15 +21,10 @@ linters:
     - nestif
     - nolintlint
     - staticcheck
-    # - stylecheck # Merged into staticcheck in v2
-    # - typecheck # Removed in v2
+    # - stylecheck # Disable stylecheck until refactor
+    - typecheck
     - unconvert
     - unused
-
-formatters:
-  enable:
-    - gofumpt
-    - goimports
 
 
 linters-settings:
@@ -45,6 +40,9 @@ linters-settings:
     disabled-checks:
       - regexpMust
       - badCall # Remove this after CI workflow PR
+
+  gofumpt:
+    lang-version: "1.24"
     
   misspell:
     ignore-words:
@@ -52,7 +50,7 @@ linters-settings:
       - cheq
       - ncheq
 
-  staticcheck:
+  stylecheck:
     # Select the Go version to target.
     go: "1.24"
     # STxxxx checks in https://staticcheck.io/docs/configuration/options/#checks
@@ -65,6 +63,14 @@ linters-settings:
     # https://staticcheck.io/docs/configuration/options/#initialisms
     initialisms: ["ACL", "API", "ASCII", "CPU", "CSS", "DNS", "EOF", "GUID", "HTML", "HTTP", "HTTPS", "ID", "IP", "JSON", "QPS", "RAM", "RPC", "SLA", "SMTP", "SQL", "SSH", "TCP", "TLS", "TTL", "UDP", "UI", "GID", "UID", "UUID", "URI", "URL", "UTF8", "VM", "XML", "XMPP", "XSRF", "XSS", "SIP", "RTP", "AMQP", "DB", "TS"]
 
+  depguard:
+    rules:
+      main:
+        files:
+          - $all
+        list-mode: lax
+        allow: "*"
+  
   goconst:
     min-occurrences: 5
     ignore-tests: true

--- a/.github/linters/.golangci.yaml
+++ b/.github/linters/.golangci.yaml
@@ -8,7 +8,7 @@ linters:
   enable:
     - bodyclose
     - copyloopvar
-    # - depguard # Disabled - no import restrictions previously
+    # - depguard # Disabled - no import restrictions applied earlier
     - dogsled
     - errcheck
     - goconst

--- a/.github/linters/.golangci.yaml
+++ b/.github/linters/.golangci.yaml
@@ -1,4 +1,4 @@
-version: 2
+version: "2"
 
 run:
   timeout: 10m
@@ -24,7 +24,7 @@ linters:
     - nolintlint
     - staticcheck
     # - stylecheck # Disable stylecheck until refactor
-    - typecheck
+    # - typecheck # Removed in v2
     - unconvert
     - unused
 

--- a/.github/linters/.golangci.yaml
+++ b/.github/linters/.golangci.yaml
@@ -71,7 +71,7 @@ linters-settings:
         files:
           - $all
         list-mode: lax
-        allow: "*"
+        # With list-mode: lax, packages are allowed unless explicitly denied
   
   goconst:
     min-occurrences: 5

--- a/.github/linters/.golangci.yaml
+++ b/.github/linters/.golangci.yaml
@@ -8,7 +8,7 @@ linters:
   enable:
     - bodyclose
     - copyloopvar
-    - depguard
+    # - depguard # Disabled - no import restrictions previously
     - dogsled
     - errcheck
     - goconst
@@ -65,9 +65,6 @@ linters-settings:
     # https://staticcheck.io/docs/configuration/options/#initialisms
     initialisms: ["ACL", "API", "ASCII", "CPU", "CSS", "DNS", "EOF", "GUID", "HTML", "HTTP", "HTTPS", "ID", "IP", "JSON", "QPS", "RAM", "RPC", "SLA", "SMTP", "SQL", "SSH", "TCP", "TLS", "TTL", "UDP", "UI", "GID", "UID", "UUID", "URI", "URL", "UTF8", "VM", "XML", "XMPP", "XSRF", "XSS", "SIP", "RTP", "AMQP", "DB", "TS"]
 
-  depguard:
-    # No rules configured - depguard will allow all dependencies by default
-  
   goconst:
     min-occurrences: 5
     ignore-tests: true

--- a/.github/linters/.golangci.yaml
+++ b/.github/linters/.golangci.yaml
@@ -66,12 +66,7 @@ linters-settings:
     initialisms: ["ACL", "API", "ASCII", "CPU", "CSS", "DNS", "EOF", "GUID", "HTML", "HTTP", "HTTPS", "ID", "IP", "JSON", "QPS", "RAM", "RPC", "SLA", "SMTP", "SQL", "SSH", "TCP", "TLS", "TTL", "UDP", "UI", "GID", "UID", "UUID", "URI", "URL", "UTF8", "VM", "XML", "XMPP", "XSRF", "XSS", "SIP", "RTP", "AMQP", "DB", "TS"]
 
   depguard:
-    rules:
-      main:
-        files:
-          - $all
-        list-mode: lax
-        # With list-mode: lax, packages are allowed unless explicitly denied
+    # No rules configured - depguard will allow all dependencies by default
   
   goconst:
     min-occurrences: 5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-go@v6
         with:
@@ -27,7 +27,7 @@ jobs:
           args: build --clean --snapshot --single-target
 
       - name: Store artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: cheqd-noded
           path: dist/did-resolver_linux_amd64_v1/did-resolver
@@ -40,7 +40,7 @@ jobs:
       IMAGE_NAME: ${{ github.repository }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -74,7 +74,7 @@ jobs:
           cache-to: type=gha,scope=docker-build-amd64,mode=max
 
       - name: Upload staging image as an artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: did-resolver-staging
           path: did-resolver-staging.tar

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ jobs:
       security-events: write
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Run Markdown link check
         uses: tcort/github-action-markdown-link-check@v1
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-go@v6
         with:
@@ -38,7 +38,7 @@ jobs:
           cache: false
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v1.64.6
           args: --config .github/linters/.golangci.yaml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0 # Required to fetch version
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,9 +38,9 @@ jobs:
           cache: false
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: v2.7.2
+          version: v1.64.6
           args: --config .github/linters/.golangci.yaml
 
   super-lint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v1.64.6
+          version: v2.7.2
           args: --config .github/linters/.golangci.yaml
 
   super-lint:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: amannn/action-semantic-pull-request@v6
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       EXECUTE_RELEASE: ${{ steps.execute-release.outputs.EXECUTE_RELEASE }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Required to fetch version
           persist-credentials: false
@@ -75,7 +75,7 @@ jobs:
     if: needs.release-guard.outputs.EXECUTE_RELEASE == 'true'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -115,7 +115,7 @@ jobs:
             runs-on: ubuntu-24.04-arm
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -150,7 +150,7 @@ jobs:
       url: https://resolver.cheqd.net
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -26,7 +26,7 @@ jobs:
         run: doctl registry login --expiry-seconds 600
 
       - name: Download Docker image
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: did-resolver-staging
 
@@ -52,7 +52,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download Docker image
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: did-resolver-staging
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-go@v6
         with:
@@ -34,10 +34,10 @@ jobs:
       IMAGE_NAME: ${{ github.repository }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Download Docker image
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: did-resolver-staging
 
@@ -67,7 +67,7 @@ jobs:
         run: docker compose -f tests/docker-compose-testing.yml logs --tail --follow
 
       - name: Upload integration tests result
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: report-integration.xml
           path: tests/integration/rest/report-integration.xml


### PR DESCRIPTION
This PR updates all the packages in CI workflows. It also disables `depguard` linter as all the deps were being allowed earlier anyway. 

The failing tests on this PR is due the the issues found by the updated `golang-lint` in the codebase.